### PR TITLE
chore(k8s): add base kubernetes manifests

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: archon-config
+  namespace: archon
+data:
+  APP_ENV: "production"
+  LOG_LEVEL: "info"
+  API_URL: "http://server-service.archon.svc.cluster.local"

--- a/k8s/deployments/frontend-deployment.yaml
+++ b/k8s/deployments/frontend-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-deployment
+  namespace: archon
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: archon/frontend:latest
+        ports:
+        - containerPort: 3000
+        env:
+        - name: API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: archon-config
+              key: API_URL

--- a/k8s/deployments/server-deployment.yaml
+++ b/k8s/deployments/server-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server-deployment
+  namespace: archon
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: server
+  template:
+    metadata:
+      labels:
+        app: server
+    spec:
+      containers:
+      - name: server
+        image: archon/server:latest
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: archon-secrets
+              key: DATABASE_URL
+        - name: API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: archon-secrets
+              key: API_KEY
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: archon-config
+              key: LOG_LEVEL

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: server-hpa
+  namespace: archon
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: server-deployment
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: archon-ingress
+  namespace: archon
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: archon.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-service
+            port:
+              number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: archon

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: archon-secrets
+  namespace: archon
+type: Opaque
+stringData:
+  DATABASE_URL: "${DATABASE_URL}"
+  API_KEY: "${API_KEY}"

--- a/k8s/services/frontend-service.yaml
+++ b/k8s/services/frontend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+  namespace: archon
+spec:
+  selector:
+    app: frontend
+  ports:
+  - port: 80
+    targetPort: 3000

--- a/k8s/services/server-service.yaml
+++ b/k8s/services/server-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-service
+  namespace: archon
+spec:
+  selector:
+    app: server
+  ports:
+  - port: 8000
+    targetPort: 8000


### PR DESCRIPTION
## Summary
- add namespace, configmap, secret, ingress, and hpa manifests
- add server and frontend deployments referencing secrets via env vars
- add services for server and frontend

## Testing
- `uv run pytest`
- `npm run test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ef6c827c83228e5a748a493fea4a