### PR TITLE
docs: add environment template and onboarding note

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Environment variables for ARCHON RELOADED
+# Replace placeholder values with your own in a local .env file.
+
+# Supabase configuration
+SUPABASE_URL=https://example.supabase.co
+SUPABASE_SERVICE_KEY=your-supabase-service-key
+
+# API keys
+OPENAI_API_KEY=your-openai-api-key
+LOGFIRE_TOKEN=your-logfire-token
+
+# Service configuration
+LOG_LEVEL=INFO
+ARCHON_SERVER_PORT=8181
+ARCHON_MCP_PORT=8051
+ARCHON_AGENTS_PORT=8052
+ARCHON_UI_PORT=3737
+HOST=localhost

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ cd ARCHONRELOADED
 
 # Configure environment
 cp .env.example .env
+# See .env.example for all required variables
 # Edit .env with your Supabase credentials
 
 # Start all services
@@ -30,6 +31,8 @@ docker-compose up -d
 # Access the platform
 open http://localhost:3737
 ```
+
+See [.env.example](.env.example) for the full list of required API keys and database settings.
 
 **🎯 Ready in 3 minutes** - ARCHON provides a complete AI development environment with knowledge management, real-time collaboration, and MCP integration for AI coding assistants.
 


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder API keys and database config
- guide new contributors to the env template in README quick start

## Testing
- `uv run pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f54590d48322885c166832722815