### PR TITLE
feat(infrastructure): add helm, terraform, and monitoring templates

### DIFF
--- a/infrastructure/helm/archon-embeddings/Chart.yaml
+++ b/infrastructure/helm/archon-embeddings/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: archon-embeddings
+description: Helm chart for archon-embeddings service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/infrastructure/helm/archon-embeddings/templates/deployment.yaml
+++ b/infrastructure/helm/archon-embeddings/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "archon-embeddings.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "archon-embeddings.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "archon-embeddings.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecret.name }}
+                  key: {{ .Values.envSecret.key }}
+

--- a/infrastructure/helm/archon-embeddings/values.schema.json
+++ b/infrastructure/helm/archon-embeddings/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      },
+      "required": ["type", "port"]
+    },
+    "envSecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "key"]
+    }
+  },
+  "required": ["replicaCount", "image", "service", "envSecret"]
+}
+

--- a/infrastructure/helm/archon-embeddings/values.yaml
+++ b/infrastructure/helm/archon-embeddings/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+image:
+  repository: archon/archon-embeddings
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+envSecret:
+  name: archon-embeddings-secrets
+  key: apiKey
+

--- a/infrastructure/helm/archon-engine/Chart.yaml
+++ b/infrastructure/helm/archon-engine/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: archon-engine
+description: Helm chart for archon-engine service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/infrastructure/helm/archon-engine/templates/deployment.yaml
+++ b/infrastructure/helm/archon-engine/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "archon-engine.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "archon-engine.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "archon-engine.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecret.name }}
+                  key: {{ .Values.envSecret.key }}
+

--- a/infrastructure/helm/archon-engine/values.schema.json
+++ b/infrastructure/helm/archon-engine/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      },
+      "required": ["type", "port"]
+    },
+    "envSecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "key"]
+    }
+  },
+  "required": ["replicaCount", "image", "service", "envSecret"]
+}
+

--- a/infrastructure/helm/archon-engine/values.yaml
+++ b/infrastructure/helm/archon-engine/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+image:
+  repository: archon/archon-engine
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+envSecret:
+  name: archon-engine-secrets
+  key: apiKey
+

--- a/infrastructure/helm/archon-mcp/Chart.yaml
+++ b/infrastructure/helm/archon-mcp/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: archon-mcp
+description: Helm chart for archon-mcp service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/infrastructure/helm/archon-mcp/templates/deployment.yaml
+++ b/infrastructure/helm/archon-mcp/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "archon-mcp.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "archon-mcp.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "archon-mcp.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecret.name }}
+                  key: {{ .Values.envSecret.key }}
+

--- a/infrastructure/helm/archon-mcp/values.schema.json
+++ b/infrastructure/helm/archon-mcp/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      },
+      "required": ["type", "port"]
+    },
+    "envSecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "key"]
+    }
+  },
+  "required": ["replicaCount", "image", "service", "envSecret"]
+}
+

--- a/infrastructure/helm/archon-mcp/values.yaml
+++ b/infrastructure/helm/archon-mcp/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+image:
+  repository: archon/archon-mcp
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+envSecret:
+  name: archon-mcp-secrets
+  key: apiKey
+

--- a/infrastructure/helm/mongodb/Chart.yaml
+++ b/infrastructure/helm/mongodb/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: mongodb
+description: Helm chart for mongodb service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/infrastructure/helm/mongodb/templates/deployment.yaml
+++ b/infrastructure/helm/mongodb/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mongodb.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "mongodb.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "mongodb.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecret.name }}
+                  key: {{ .Values.envSecret.key }}
+

--- a/infrastructure/helm/mongodb/values.schema.json
+++ b/infrastructure/helm/mongodb/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      },
+      "required": ["type", "port"]
+    },
+    "envSecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "key"]
+    }
+  },
+  "required": ["replicaCount", "image", "service", "envSecret"]
+}
+

--- a/infrastructure/helm/mongodb/values.yaml
+++ b/infrastructure/helm/mongodb/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+image:
+  repository: archon/mongodb
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+envSecret:
+  name: mongodb-secrets
+  key: apiKey
+

--- a/infrastructure/helm/qdrant/Chart.yaml
+++ b/infrastructure/helm/qdrant/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: qdrant
+description: Helm chart for qdrant service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/infrastructure/helm/qdrant/templates/deployment.yaml
+++ b/infrastructure/helm/qdrant/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "qdrant.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "qdrant.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "qdrant.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecret.name }}
+                  key: {{ .Values.envSecret.key }}
+

--- a/infrastructure/helm/qdrant/values.schema.json
+++ b/infrastructure/helm/qdrant/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      },
+      "required": ["type", "port"]
+    },
+    "envSecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "key"]
+    }
+  },
+  "required": ["replicaCount", "image", "service", "envSecret"]
+}
+

--- a/infrastructure/helm/qdrant/values.yaml
+++ b/infrastructure/helm/qdrant/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+image:
+  repository: archon/qdrant
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+envSecret:
+  name: qdrant-secrets
+  key: apiKey
+

--- a/infrastructure/helm/redis/Chart.yaml
+++ b/infrastructure/helm/redis/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: redis
+description: Helm chart for redis service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/infrastructure/helm/redis/templates/deployment.yaml
+++ b/infrastructure/helm/redis/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redis.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "redis.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "redis.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecret.name }}
+                  key: {{ .Values.envSecret.key }}
+

--- a/infrastructure/helm/redis/values.schema.json
+++ b/infrastructure/helm/redis/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      },
+      "required": ["type", "port"]
+    },
+    "envSecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "key"]
+    }
+  },
+  "required": ["replicaCount", "image", "service", "envSecret"]
+}
+

--- a/infrastructure/helm/redis/values.yaml
+++ b/infrastructure/helm/redis/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+image:
+  repository: archon/redis
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+envSecret:
+  name: redis-secrets
+  key: apiKey
+

--- a/infrastructure/monitoring/grafana/datasources.yml
+++ b/infrastructure/monitoring/grafana/datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    basicAuth: true
+    basicAuthUser: admin
+    basicAuthPassword: ${GRAFANA_PROM_PASSWORD}
+

--- a/infrastructure/monitoring/loki/config.yml
+++ b/infrastructure/monitoring/loki/config.yml
@@ -1,0 +1,19 @@
+auth_enabled: false
+server:
+  http_listen_port: 3100
+storage_config:
+  filesystem:
+    directory: ${LOKI_STORAGE_DIR}
+chunk_store_config:
+  max_look_back_period: 0s
+schema_config:
+  configs:
+    - from: 2020-10-15
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+

--- a/infrastructure/monitoring/prometheus/prometheus.yml
+++ b/infrastructure/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+

--- a/infrastructure/monitoring/tempo/config.yml
+++ b/infrastructure/monitoring/tempo/config.yml
@@ -1,0 +1,11 @@
+auth_enabled: false
+server:
+  http_listen_port: 3200
+storage:
+  trace:
+    backend: local
+    wal:
+      path: ${TEMPO_WAL_PATH}
+    local:
+      path: ${TEMPO_LOCAL_PATH}
+

--- a/infrastructure/terraform/aws/main.tf
+++ b/infrastructure/terraform/aws/main.tf
@@ -1,0 +1,48 @@
+# AWS credentials are sourced from the environment:
+# AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  validation {
+    condition     = length(var.cluster_name) >= 3 && length(var.cluster_name) <= 30
+    error_message = "cluster_name must be 3-30 characters."
+  }
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  validation {
+    condition     = can(regex("^([a-z]{2}-){2}[0-9]$", var.region))
+    error_message = "region must match pattern e.g. us-west-2."
+  }
+}
+
+variable "cluster_role_arn" {
+  description = "IAM role ARN for EKS cluster"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs"
+  type        = list(string)
+  validation {
+    condition     = length(var.subnet_ids) > 0
+    error_message = "At least one subnet ID must be provided."
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_eks_cluster" "archon" {
+  name     = var.cluster_name
+  role_arn = var.cluster_role_arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+}
+

--- a/infrastructure/terraform/azure/main.tf
+++ b/infrastructure/terraform/azure/main.tf
@@ -1,0 +1,31 @@
+# Azure credentials are sourced from the environment: ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID
+
+variable "resource_group_name" {
+  description = "Azure resource group"
+  type        = string
+  validation {
+    condition     = length(var.resource_group_name) > 0
+    error_message = "resource_group_name must not be empty."
+  }
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+  validation {
+    condition     = length(var.location) > 0
+    error_message = "location must not be empty."
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_kubernetes_cluster" "archon" {
+  name                = "archon-cluster"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  dns_prefix          = "archon"
+}
+

--- a/infrastructure/terraform/gcp/main.tf
+++ b/infrastructure/terraform/gcp/main.tf
@@ -1,0 +1,30 @@
+# GCP credentials are sourced from the environment via GOOGLE_APPLICATION_CREDENTIALS
+
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+  validation {
+    condition     = length(var.project) > 0
+    error_message = "project must not be empty."
+  }
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "region must not be empty."
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+resource "google_container_cluster" "archon" {
+  name     = "${var.project}-archon"
+  location = var.region
+}
+


### PR DESCRIPTION
## Summary
- scaffold helm charts for core services with secret references
- add terraform templates for AWS, GCP, and Azure cluster provisioning
- include monitoring configs for Prometheus, Grafana, Loki, and Tempo

## Testing
- `uv run pytest`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fd2df5d08322bbdb705c63b1f6cf