### PR TITLE
docs: add project strategic analysis report

### DIFF
--- a/ARCHON_DEVELOPMENT_REPORT.md
+++ b/ARCHON_DEVELOPMENT_REPORT.md
@@ -1,0 +1,41 @@
+## Executive Summary
+ARCHON RELOADED aims to be a microservices-based AI development platform integrating AI coding tools via the Model Context Protocol (MCP). The repository currently contains foundational documentation, a minimal Next.js frontend, and TypeScript utilities for MCP, engine task execution, and embeddings. Core backend services and RAG features described in the project plan are not yet implemented. Immediate focus should be establishing the Python FastAPI services and enhancing security, testing, and CI/CD practices.
+
+## Current Development Stage
+**Scaffolding & Conceptualization** – The project has project structure, configuration files, and early frontend/TypeScript utilities, but lacks the core FastAPI backend, MCP server, agents service, and real-time features outlined in the project goals.
+
+## Project Health Analysis
+### Feature Progress
+- **Completed**: Basic frontend page, API client utility with validation and retries, TypeScript modules for secure HTTP, MCP fetch, engine tasks, and embedding generation.
+- **In Progress**: Test suites for frontend and TypeScript utilities.
+- **Pending**: FastAPI backend services, RAG pipeline, project/task management, WebSocket collaboration, Supabase integration.
+
+### Architectural Integrity
+- The repository structure partially follows the documented architecture, including a dedicated React frontend directory and migration scripts, but the `/python` backend directory is absent, leaving the microservices architecture incomplete.
+- Infrastructure configurations (Helm charts, Terraform, Kubernetes manifests) are present, suggesting deployment planning is underway.
+
+### Tech Stack Grade
+- **TypeScript/Frontend**: Good use of async/await, input validation, environment variables, retry/timeout logic, and unit tests.
+- **Python Backend**: Not yet present; planned FastAPI services and Pydantic models are missing.
+- **Documentation**: Extensive AGENTS and README files provide guidance and setup instructions.
+
+### Test Coverage & Automation
+- TypeScript utilities: Vitest suite with ~94% statement coverage.
+- Frontend: Vitest unit tests pass; no coverage metrics yet.
+- Python: No tests (backend absent).
+- CI/CD: No GitHub Actions or similar pipelines configured.
+
+## Recommended Continuation Paths
+### Rapid Path to MVP
+1. Scaffold the FastAPI backend (`python/src/server/main.py`) with endpoints for status checks and basic project data.
+2. Implement Supabase integration using environment variables for credentials.
+3. Connect frontend to backend via `/status` endpoint and expand API client tests to cover error scenarios.
+4. Establish minimal CI using GitHub Actions running `uv run pytest` and `npm test`.
+
+### Scalable Path to Production
+1. Build out MCP server and agents service with input validation, custom exceptions, and retry logic for external APIs.
+2. Implement RAG pipeline using Supabase pgvector and Redis caching; secure operations via environment-configured keys and sanitized inputs.
+3. Containerize services and define Kubernetes deployments with resource limits and health checks.
+4. Add comprehensive test suites (unit, integration, E2E) targeting 80%+ coverage and enforce via CI.
+5. Introduce observability stack (Prometheus, Grafana, Loki) and centralized structured logging for microservices.
+


### PR DESCRIPTION
## Summary
- add high-level assessment of project status, architecture, and test coverage

## Testing
- `npm test` (nodejs)
- `npm test` (archon-ui-main)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a201b8c0b483229388b45b00369483