### PR TITLE
fix(utils): add jittered exponential backoff

### DIFF
--- a/nodejs/src/tests/http.test.ts
+++ b/nodejs/src/tests/http.test.ts
@@ -3,22 +3,61 @@ import { secureFetch, HTTPError } from '../utils/http'
 
 describe('secureFetch', () => {
   const originalFetch = global.fetch
+
   beforeEach(() => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'err' })
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500, statusText: 'err' })
   })
+
   afterEach(() => {
     global.fetch = originalFetch
+    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
+
   it('rejects invalid url', async () => {
-    await expect(secureFetch('bad')).rejects.toBeTruthy()
+    await expect(secureFetch('bad')).rejects.toBeInstanceOf(HTTPError)
   })
-  it('retries and throws HTTPError', async () => {
-    await expect(secureFetch('https://example.com')).rejects.toBeInstanceOf(HTTPError)
+
+  it('honors max retries and throws HTTPError', async () => {
+    vi.useFakeTimers()
+    const p = secureFetch('https://example.com', {}, 2, 1)
+    p.catch(() => {})
+    await vi.runAllTimersAsync()
+    await expect(p).rejects.toBeInstanceOf(HTTPError)
     expect((global.fetch as any).mock.calls.length).toBe(3)
   })
+
+  it('uses exponential backoff with jitter', async () => {
+    vi.useFakeTimers()
+    const spy = vi.spyOn(global, 'setTimeout')
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const p = secureFetch('https://example.com', {}, 2, 1)
+    p.catch(() => {})
+    await vi.runAllTimersAsync()
+    await expect(p).rejects.toBeInstanceOf(HTTPError)
+    const base = spy.mock.calls
+      .map((c) => c[1] as number)
+      .filter((d) => d !== 1)
+    expect(base[1]).toBeGreaterThanOrEqual(base[0] * 2)
+    spy.mockClear()
+    ;(global.fetch as any).mockClear()
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const p2 = secureFetch('https://example.com', {}, 1, 1)
+    p2.catch(() => {})
+    await vi.runAllTimersAsync()
+    await expect(p2).rejects.toBeInstanceOf(HTTPError)
+    const jitter = spy.mock.calls
+      .map((c) => c[1] as number)
+      .filter((d) => d !== 1)
+    expect(jitter[0]).toBeGreaterThan(base[0])
+  })
+
   it('returns on success', async () => {
-    (global.fetch as any).mockResolvedValueOnce({ ok: true })
+    ;(global.fetch as any).mockResolvedValueOnce({ ok: true })
     const res = await secureFetch('https://example.com')
     expect(res.ok).toBe(true)
   })
 })
+

--- a/nodejs/src/utils/http.ts
+++ b/nodejs/src/utils/http.ts
@@ -5,6 +5,8 @@ export class HTTPError extends Error {
   }
 }
 
+const BASE_DELAY = 100
+
 export async function secureFetch(
   url: string,
   options: RequestInit = {},
@@ -14,18 +16,24 @@ export async function secureFetch(
   try {
     new URL(url)
   } catch {
-    throw new Error('Invalid URL')
+    throw new HTTPError(0, 'Invalid URL')
   }
-  const controller = new AbortController()
-  const id = setTimeout(() => controller.abort(), timeout)
-  try {
-    const res = await fetch(url, { ...options, signal: controller.signal })
-    if (!res.ok) throw new HTTPError(res.status, res.statusText)
-    return res
-  } catch (err) {
-    if (retries > 0) return secureFetch(url, options, retries - 1, timeout)
-    throw err instanceof Error ? err : new Error('Unknown error')
-  } finally {
-    clearTimeout(id)
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController()
+    const id = setTimeout(() => controller.abort(), timeout)
+    try {
+      const res = await fetch(url, { ...options, signal: controller.signal })
+      if (!res.ok) throw new HTTPError(res.status, res.statusText)
+      return res
+    } catch (err) {
+      if (attempt === retries) {
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        throw err instanceof HTTPError ? err : new HTTPError(0, message)
+      }
+      await new Promise((r) => setTimeout(r, BASE_DELAY * 2 ** attempt + Math.random() * BASE_DELAY))
+    } finally {
+      clearTimeout(id)
+    }
   }
+  throw new HTTPError(0, 'Failed to fetch')
 }


### PR DESCRIPTION
## Summary
- replace recursive HTTP retry logic with loop and jittered exponential backoff
- validate URLs and raise HTTPError for invalid input
- test secureFetch retry limits and backoff timing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2085115c88322a4ed175f4af3502d