### PR TITLE
fix(ui): validate API base URL and add typed apiGet

### DIFF
--- a/archon-ui-main/__tests__/apiClient.test.ts
+++ b/archon-ui-main/__tests__/apiClient.test.ts
@@ -1,10 +1,20 @@
 import { apiGet, ApiError } from '../src/services/apiClient'
 
-process.env.NEXT_PUBLIC_API_BASE_URL = 'http://example.com'
-
 describe('apiGet', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://example.com'
+  })
+
   it('throws on invalid path', async () => {
     await expect(apiGet('')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('throws on invalid base URL', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'not-a-url'
+    // @ts-ignore: override for test
+    global.fetch = vi.fn()
+    await expect(apiGet('/test')).rejects.toBeInstanceOf(ApiError)
+    expect(global.fetch).not.toHaveBeenCalled()
   })
 
   it('retries and fails', async () => {
@@ -13,5 +23,16 @@ describe('apiGet', () => {
     global.fetch = fetchMock
     await expect(apiGet('/test', 1, 10)).rejects.toBeInstanceOf(ApiError)
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns typed response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: 'ok' }),
+    })
+    // @ts-ignore: override for test
+    global.fetch = fetchMock
+    const data = await apiGet<{ value: string }>('/test')
+    expect(data.value).toBe('ok')
   })
 })

--- a/archon-ui-main/src/services/apiClient.ts
+++ b/archon-ui-main/src/services/apiClient.ts
@@ -12,10 +12,18 @@ const pathSchema = z.string().min(1)
 function getBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_BASE_URL
   if (!url) throw new ApiError('API base URL not configured')
-  return url
+  try {
+    return new URL(url).toString()
+  } catch {
+    throw new ApiError('Invalid API base URL')
+  }
 }
 
-export async function apiGet(path: string, retries = 3, timeout = 5000): Promise<unknown> {
+export async function apiGet<T>(
+  path: string,
+  retries = 3,
+  timeout = 5000,
+): Promise<T> {
   const result = pathSchema.safeParse(path)
   if (!result.success) throw new ApiError('Invalid path')
   const urlPath = result.data
@@ -25,10 +33,13 @@ export async function apiGet(path: string, retries = 3, timeout = 5000): Promise
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeout)
     try {
-      const res = await fetch(`${baseUrl}${urlPath}`, { signal: controller.signal })
+      const res = await fetch(`${baseUrl}${urlPath}`, {
+        signal: controller.signal,
+      })
       clearTimeout(timer)
       if (!res.ok) throw new ApiError(`Request failed: ${res.status}`)
-      return await res.json()
+      const data: T = await res.json()
+      return data
     } catch (err) {
       clearTimeout(timer)
       if (attempt === retries) {


### PR DESCRIPTION
## Summary
- validate NEXT_PUBLIC_API_BASE_URL with URL parsing
- add generic apiGet<T> with typed responses
- test invalid base URL handling and typed fetch results

## Testing
- `npm test`
- `npm run build`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a215cf541c8322b0f9a5d20e46b6bd