### PR TITLE
test(ui): enable e2e test and add CI workflow

### DIFF
--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -1,0 +1,31 @@
+name: ui-e2e
+
+on:
+  push:
+    paths:
+      - 'archon-ui-main/**'
+      - '.github/workflows/ui-e2e.yml'
+  pull_request:
+    paths:
+      - 'archon-ui-main/**'
+      - '.github/workflows/ui-e2e.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: archon-ui-main/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: archon-ui-main
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: archon-ui-main
+      - name: Run E2E tests
+        run: npm run test:e2e
+        working-directory: archon-ui-main

--- a/archon-ui-main/__tests__/e2e.spec.ts
+++ b/archon-ui-main/__tests__/e2e.spec.ts
@@ -1,5 +1,8 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
-test.skip('homepage loads', async ({ page }) => {
+test('homepage loads', async ({ page }) => {
   await page.goto('/')
+  await expect(
+    page.getByRole('heading', { name: 'ARCHON RELOADED' })
+  ).toBeVisible()
 })

--- a/archon-ui-main/playwright.config.ts
+++ b/archon-ui-main/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: '__tests__',
@@ -7,4 +7,10 @@ export default defineConfig({
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
-});
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+})


### PR DESCRIPTION
## Summary
- add Playwright e2e test for homepage
- start Next.js dev server in Playwright config
- run UI e2e tests in GitHub Actions

## Testing
- `npm test`
- `npm run test:e2e`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2179796748322a118d23ab54f1182