### PR TITLE
refactor(common): centralize FastAPI service setup

### DIFF
--- a/python/src/agents/main.py
+++ b/python/src/agents/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from src.common.service import create_service
 from src.utils import ExternalServiceError
 
 
@@ -8,12 +9,7 @@ class TaskRequest(BaseModel):
     task: str = Field(..., min_length=1, max_length=100)
 
 
-app = FastAPI()
-
-
-@app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
+app = create_service()
 
 
 @app.post("/run")

--- a/python/src/common/service.py
+++ b/python/src/common/service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from src.utils import ExternalServiceError
+
+
+async def _health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+def create_service() -> FastAPI:
+    """Create a FastAPI app with health and error handlers."""
+    app = FastAPI()
+    app.get("/health")(_health)
+
+    @app.exception_handler(ExternalServiceError)
+    async def _handle_external(_: Request, exc: ExternalServiceError) -> JSONResponse:
+        return JSONResponse(status_code=502, content={"detail": str(exc)})
+
+    @app.exception_handler(Exception)
+    async def _handle_general(_: Request, exc: Exception) -> JSONResponse:
+        return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+    return app

--- a/python/src/mcp/main.py
+++ b/python/src/mcp/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from src.common.service import create_service
 from src.utils import ExternalServiceError
 
 
@@ -8,12 +9,7 @@ class CommandRequest(BaseModel):
     command: str = Field(..., min_length=1, max_length=50)
 
 
-app = FastAPI()
-
-
-@app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
+app = create_service()
 
 
 @app.post("/execute")

--- a/python/src/server/main.py
+++ b/python/src/server/main.py
@@ -1,27 +1,19 @@
-from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from src.utils import ExternalServiceError, fetch_with_retry
+from src.common.service import create_service
+from src.utils import fetch_with_retry
 
 
 class ProcessRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=100)
 
 
-app = FastAPI()
-
-
-@app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
+app = create_service()
 
 
 @app.post("/process")
 async def process(req: ProcessRequest) -> dict[str, str]:
-    try:
-        data = await fetch_with_retry("get")
-    except ExternalServiceError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    data = await fetch_with_retry("get")
     return {"echo": req.text, "data": data.get("url", "")}
 
 

--- a/python/tests/test_agents.py
+++ b/python/tests/test_agents.py
@@ -5,6 +5,15 @@ from src.agents.main import app
 
 
 @pytest.mark.asyncio
+async def test_health() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
 async def test_run_compute() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -5,6 +5,15 @@ from src.mcp.main import app
 
 
 @pytest.mark.asyncio
+async def test_health() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
 async def test_execute_ping() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/python/tests/test_service.py
+++ b/python/tests/test_service.py
@@ -1,0 +1,30 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.common.service import create_service
+from src.utils import ExternalServiceError
+
+
+@pytest.mark.asyncio
+async def test_create_service_health() -> None:
+    app = create_service()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_error_handler() -> None:
+    app = create_service()
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise ExternalServiceError("fail")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.get("/boom")
+    assert res.status_code == 502
+    assert res.json()["detail"] == "fail"


### PR DESCRIPTION
## Summary
- create `create_service` factory for shared FastAPI app with health check and error handlers
- refactor server, mcp, and agents services to use the shared factory
- expand tests for health endpoints and new service factory

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23c04e2348322b10db2e5e29d2969