### PR TITLE
refactor(node): centralize pino logger

### DIFF
--- a/nodejs/src/embeddings/index.ts
+++ b/nodejs/src/embeddings/index.ts
@@ -1,7 +1,5 @@
-import pino from 'pino'
+import { logger } from '../utils/logger'
 import { secureFetch } from '../utils/http'
-
-export const logger = pino()
 
 export class EmbeddingError extends Error {
   constructor(message: string) {

--- a/nodejs/src/engine/index.ts
+++ b/nodejs/src/engine/index.ts
@@ -1,7 +1,5 @@
-import pino from 'pino'
+import { logger } from '../utils/logger'
 import { secureFetch } from '../utils/http'
-
-export const logger = pino()
 
 export class EngineError extends Error {
   constructor(message: string) {

--- a/nodejs/src/mcp/index.ts
+++ b/nodejs/src/mcp/index.ts
@@ -1,7 +1,5 @@
-import pino from 'pino'
+import { logger } from '../utils/logger'
 import { secureFetch } from '../utils/http'
-
-export const logger = pino()
 
 export class MCPError extends Error {
   constructor(message: string) {

--- a/nodejs/src/tests/embeddings.test.ts
+++ b/nodejs/src/tests/embeddings.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { generateEmbedding, EmbeddingError, logger } from '../embeddings'
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+import { generateEmbedding, EmbeddingError } from '../embeddings'
+import { logger } from '../utils/logger'
 
 describe('generateEmbedding', () => {
   const originalFetch = global.fetch
   beforeEach(() => {
     process.env.EMBEDDINGS_URL = 'https://emb.example.com'
-    vi.spyOn(logger, 'info')
-    vi.spyOn(logger, 'error')
   })
   afterEach(() => {
     global.fetch = originalFetch
     delete process.env.EMBEDDINGS_URL
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
   it('rejects invalid text', async () => {
     await expect(generateEmbedding('')).rejects.toBeInstanceOf(EmbeddingError)

--- a/nodejs/src/tests/engine.test.ts
+++ b/nodejs/src/tests/engine.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { runEngineTask, EngineError, logger } from '../engine'
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+import { runEngineTask, EngineError } from '../engine'
+import { logger } from '../utils/logger'
 
 describe('runEngineTask', () => {
   const originalFetch = global.fetch
   beforeEach(() => {
     process.env.ENGINE_URL = 'https://engine.example.com'
-    vi.spyOn(logger, 'info')
-    vi.spyOn(logger, 'error')
   })
   afterEach(() => {
     global.fetch = originalFetch
     delete process.env.ENGINE_URL
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
   it('rejects invalid id', async () => {
     await expect(runEngineTask('bad')).rejects.toBeInstanceOf(EngineError)

--- a/nodejs/src/tests/mcp.test.ts
+++ b/nodejs/src/tests/mcp.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { fetchMCP, MCPError, logger } from '../mcp'
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+import { fetchMCP, MCPError } from '../mcp'
+import { logger } from '../utils/logger'
 
 describe('fetchMCP', () => {
   const originalFetch = global.fetch
   beforeEach(() => {
     process.env.MCP_BASE_URL = 'https://api.example.com'
-    vi.spyOn(logger, 'info')
-    vi.spyOn(logger, 'error')
   })
   afterEach(() => {
     global.fetch = originalFetch
     delete process.env.MCP_BASE_URL
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
   it('rejects invalid resource', async () => {
     await expect(fetchMCP('bad resource')).rejects.toBeInstanceOf(MCPError)

--- a/nodejs/src/utils/logger.ts
+++ b/nodejs/src/utils/logger.ts
@@ -1,0 +1,5 @@
+import pino from 'pino'
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+})


### PR DESCRIPTION
## Summary
- add shared pino logger utility
- use shared logger in engine, mcp, and embeddings modules
- mock shared logger in tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a24b80c9348322a2360a3e6f8f2f31