### PR TITLE
feat(ui): add backoff and logging to apiGet

### DIFF
--- a/archon-ui-main/src/utils/logger.ts
+++ b/archon-ui-main/src/utils/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info(message: string): void {
+    console.log(message)
+  },
+}


### PR DESCRIPTION
## Summary
- add lightweight logger
- implement exponential backoff with retry logging in apiGet
- extend tests for backoff delay and logging

## Testing
- `cd archon-ui-main && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a24f2cd81c8322a79062244cfd8fe2