### PR TITLE
feat(server): add pydantic models for core entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.venv/

--- a/python/src/server/models/__init__.py
+++ b/python/src/server/models/__init__.py
@@ -1,0 +1,18 @@
+from .base import ResponseModel, ResponseStatus, TimestampedModel
+from .project import Project, ProjectStatus
+from .source import Source, SourceStatus, SourceType
+from .document import Document
+from .query import Query
+
+__all__ = [
+    "ResponseModel",
+    "ResponseStatus",
+    "TimestampedModel",
+    "Project",
+    "ProjectStatus",
+    "Source",
+    "SourceStatus",
+    "SourceType",
+    "Document",
+    "Query",
+]

--- a/python/src/server/models/base.py
+++ b/python/src/server/models/base.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Generic, Optional, TypeVar
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+T = TypeVar("T")
+
+
+class TimestampedModel(BaseModel):
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @field_validator("created_at", "updated_at")
+    @classmethod
+    def ensure_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must be timezone-aware")
+        return value
+
+
+class ResponseStatus(str, Enum):
+    SUCCESS = "success"
+    ERROR = "error"
+
+
+class ResponseModel(BaseModel, Generic[T]):
+    status: ResponseStatus
+    data: Optional[T] = None
+    error: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_error(self) -> "ResponseModel[T]":
+        if self.status is ResponseStatus.ERROR and not self.error:
+            raise ValueError("error message required when status is ERROR")
+        return self

--- a/python/src/server/models/document.py
+++ b/python/src/server/models/document.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from uuid import UUID
+from pydantic import Field, UUID4, field_validator
+
+from .base import TimestampedModel
+
+
+class Document(TimestampedModel):
+    id: UUID4
+    source_id: UUID4
+    content: str
+    embeddings: List[float] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("id", "source_id")
+    @classmethod
+    def validate_uuid4(cls, value: UUID) -> UUID4:
+        if value.version != 4:
+            raise ValueError("must be a valid UUID4")
+        return UUID4(str(value))

--- a/python/src/server/models/project.py
+++ b/python/src/server/models/project.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, Optional
+from uuid import UUID
+from pydantic import Field, UUID4, field_validator
+
+from .base import TimestampedModel
+
+
+class ProjectStatus(str, Enum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class Project(TimestampedModel):
+    id: UUID4
+    name: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=500)
+    status: ProjectStatus = ProjectStatus.ACTIVE
+    settings: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("id")
+    @classmethod
+    def validate_uuid4(cls, value: UUID) -> UUID4:
+        if value.version != 4:
+            raise ValueError("id must be a valid UUID4")
+        return UUID4(str(value))

--- a/python/src/server/models/query.py
+++ b/python/src/server/models/query.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+from pydantic import BaseModel, Field
+
+
+class Query(BaseModel):
+    query_text: str = Field(..., min_length=1)
+    match_count: int = Field(default=5, ge=1, le=100)
+    filters: Dict[str, Any] = Field(default_factory=dict)
+    threshold: float = Field(default=0.5, ge=0.0, le=1.0)

--- a/python/src/server/models/source.py
+++ b/python/src/server/models/source.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, Optional
+from uuid import UUID
+from pydantic import Field, HttpUrl, UUID4, field_validator
+
+from .base import TimestampedModel
+
+
+class SourceType(str, Enum):
+    WEB = "web"
+    FILE = "file"
+    OTHER = "other"
+
+
+class SourceStatus(str, Enum):
+    PENDING = "pending"
+    READY = "ready"
+    FAILED = "failed"
+
+
+class Source(TimestampedModel):
+    id: UUID4
+    project_id: UUID4
+    type: SourceType
+    url: HttpUrl
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    status: SourceStatus = SourceStatus.PENDING
+
+    @field_validator("id", "project_id")
+    @classmethod
+    def validate_uuid4(cls, value: UUID) -> UUID4:
+        if value.version != 4:
+            raise ValueError("must be a valid UUID4")
+        return UUID4(str(value))

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from uuid import UUID
+
+from src.server.models import (
+    Document,
+    Project,
+    ProjectStatus,
+    Query,
+    ResponseModel,
+    ResponseStatus,
+    Source,
+    SourceStatus,
+    SourceType,
+)
+
+
+def test_project_name_length_validation() -> None:
+    with pytest.raises(ValidationError):
+        Project(
+            id=UUID("12345678-1234-5678-1234-567812345678"),
+            name="x" * 101,
+            description="desc",
+        )
+
+
+def test_source_url_validation() -> None:
+    with pytest.raises(ValidationError):
+        Source(
+            id=UUID("12345678-1234-5678-1234-567812345678"),
+            project_id=UUID("12345678-1234-5678-1234-567812345679"),
+            type=SourceType.WEB,
+            url="not-a-url",
+            status=SourceStatus.PENDING,
+        )
+
+
+def test_document_uuid_validation() -> None:
+    with pytest.raises(ValidationError):
+        Document(
+            id=UUID("12345678-1234-5678-1234-567812345670"),
+            source_id=UUID("12345678-1234-5678-1234-567812345671"),
+            content="text",
+        )
+
+
+def test_query_threshold_validation() -> None:
+    with pytest.raises(ValidationError):
+        Query(query_text="hello", threshold=1.5)
+
+
+def test_response_model_error_required() -> None:
+    with pytest.raises(ValidationError):
+        ResponseModel(status=ResponseStatus.ERROR)
+
+
+def test_response_model_success() -> None:
+    result = ResponseModel(status=ResponseStatus.SUCCESS, data={"ok": True})
+    assert result.data == {"ok": True}


### PR DESCRIPTION
## Summary
- add timestamped base model and generic response wrapper
- define project, source, document, and query models with validation
- cover model validation with tests

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a25a5f76fc83228ce4f5e65371f658