### PR TITLE
feat(server): add supabase database service

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.10.1",
     "python-dotenv>=1.1.1",
     "python-socketio[asgi]>=5.13.0",
+    "supabase>=2.18.1",
     "tenacity>=9.1.2",
     "uvicorn>=0.35.0",
 ]

--- a/python/src/server/database/__init__.py
+++ b/python/src/server/database/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities and migrations."""
+
+from .migrations import run_sql, MigrationError
+
+__all__ = ["run_sql", "MigrationError"]

--- a/python/src/server/database/migrations.py
+++ b/python/src/server/database/migrations.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Awaitable, Callable
+
+
+class MigrationError(Exception):
+    """Raised when a migration fails."""
+
+
+async def run_sql(path: str, executor: Callable[[str], Awaitable[None]]) -> None:
+    """Execute SQL statements from a file using the provided executor.
+
+    Args:
+        path: Path to the SQL file.
+        executor: Async callable executing a single SQL statement.
+    """
+    try:
+        sql = Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise MigrationError("migration file not found") from exc
+
+    for statement in [s.strip() for s in sql.split(";") if s.strip()]:
+        try:
+            await executor(statement)
+        except Exception as exc:  # noqa: BLE001
+            raise MigrationError(f"failed statement: {statement}") from exc

--- a/python/src/server/services/__init__.py
+++ b/python/src/server/services/__init__.py
@@ -1,0 +1,11 @@
+"""Service layer exports."""
+
+from .database import DatabaseService, DatabaseError
+from .supabase_client import SupabaseClient, SupabaseClientError
+
+__all__ = [
+    "DatabaseService",
+    "DatabaseError",
+    "SupabaseClient",
+    "SupabaseClientError",
+]

--- a/python/src/server/services/database.py
+++ b/python/src/server/services/database.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+from uuid import UUID
+
+from supabase import AsyncClient
+
+from ..models.document import Document
+from ..models.project import Project
+from ..models.query import Query
+from ..models.source import Source
+from .supabase_client import SupabaseClient
+
+
+class DatabaseError(Exception):
+    """Raised when database operations fail."""
+
+
+class DatabaseService:
+    """Service layer providing CRUD and vector operations."""
+
+    def __init__(self, client: SupabaseClient) -> None:
+        self._client = client
+
+    async def _table(self, name: str):
+        sb = await self._client.get_client()
+        return sb.table(name)
+
+    async def create_project(self, project: Project) -> Project:
+        try:
+            tbl = await self._table("projects")
+            res = await tbl.insert(project.model_dump()).execute()
+            return Project(**res.data[0])
+        except Exception as exc:
+            raise DatabaseError("create_project failed") from exc
+
+    async def get_project(self, project_id: UUID) -> Optional[Project]:
+        try:
+            tbl = await self._table("projects")
+            res = await tbl.select("*").eq("id", str(project_id)).single().execute()
+            return Project(**res.data)
+        except Exception:
+            return None
+
+    async def update_project(self, project_id: UUID, data: Dict[str, Any]) -> Optional[Project]:
+        try:
+            tbl = await self._table("projects")
+            res = (
+                await tbl.update(data).eq("id", str(project_id)).select("*").single().execute()
+            )
+            return Project(**res.data)
+        except Exception:
+            return None
+
+    async def delete_project(self, project_id: UUID) -> bool:
+        try:
+            tbl = await self._table("projects")
+            await tbl.delete().eq("id", str(project_id)).execute()
+            return True
+        except Exception:
+            return False
+
+    async def list_projects(self) -> List[Project]:
+        tbl = await self._table("projects")
+        res = await tbl.select("*").execute()
+        return [Project(**row) for row in res.data]
+
+    async def create_source(self, source: Source) -> Source:
+        try:
+            tbl = await self._table("sources")
+            res = await tbl.insert(source.model_dump()).execute()
+            return Source(**res.data[0])
+        except Exception as exc:
+            raise DatabaseError("create_source failed") from exc
+
+    async def get_source(self, source_id: UUID) -> Optional[Source]:
+        try:
+            tbl = await self._table("sources")
+            res = await tbl.select("*").eq("id", str(source_id)).single().execute()
+            return Source(**res.data)
+        except Exception:
+            return None
+
+    async def update_source(self, source_id: UUID, data: Dict[str, Any]) -> Optional[Source]:
+        try:
+            tbl = await self._table("sources")
+            res = (
+                await tbl.update(data).eq("id", str(source_id)).select("*").single().execute()
+            )
+            return Source(**res.data)
+        except Exception:
+            return None
+
+    async def delete_source(self, source_id: UUID) -> bool:
+        try:
+            tbl = await self._table("sources")
+            await tbl.delete().eq("id", str(source_id)).execute()
+            return True
+        except Exception:
+            return False
+
+    async def list_sources(self, project_id: UUID) -> List[Source]:
+        tbl = await self._table("sources")
+        res = await tbl.select("*").eq("project_id", str(project_id)).execute()
+        return [Source(**row) for row in res.data]
+
+    async def create_document(self, doc: Document) -> Document:
+        try:
+            tbl = await self._table("documents")
+            res = await tbl.insert(doc.model_dump()).execute()
+            return Document(**res.data[0])
+        except Exception as exc:
+            raise DatabaseError("create_document failed") from exc
+
+    async def get_document(self, doc_id: UUID) -> Optional[Document]:
+        try:
+            tbl = await self._table("documents")
+            res = await tbl.select("*").eq("id", str(doc_id)).single().execute()
+            return Document(**res.data)
+        except Exception:
+            return None
+
+    async def update_document(self, doc_id: UUID, data: Dict[str, Any]) -> Optional[Document]:
+        try:
+            tbl = await self._table("documents")
+            res = (
+                await tbl.update(data).eq("id", str(doc_id)).select("*").single().execute()
+            )
+            return Document(**res.data)
+        except Exception:
+            return None
+
+    async def delete_document(self, doc_id: UUID) -> bool:
+        try:
+            tbl = await self._table("documents")
+            await tbl.delete().eq("id", str(doc_id)).execute()
+            return True
+        except Exception:
+            return False
+
+    async def vector_search(self, embedding: Sequence[float], query: Query) -> List[Document]:
+        sb = await self._client.get_client()
+        try:
+            res = await sb.rpc(
+                "match_documents",
+                {
+                    "query_embedding": list(embedding),
+                    "match_count": query.match_count,
+                    "filter": query.filters,
+                    "threshold": query.threshold,
+                },
+            ).execute()
+            return [Document(**row) for row in res.data]
+        except Exception as exc:
+            raise DatabaseError("vector_search failed") from exc
+
+    async def store_embedding(self, doc_id: UUID, embedding: Sequence[float]) -> bool:
+        try:
+            tbl = await self._table("embeddings")
+            await tbl.insert({"doc_id": str(doc_id), "embedding": list(embedding)}).execute()
+            return True
+        except Exception:
+            return False
+
+    async def similarity_query(self, embedding: Sequence[float], top_k: int) -> List[Dict[str, Any]]:
+        sb = await self._client.get_client()
+        res = await sb.rpc(
+            "match_embeddings",
+            {"query_embedding": list(embedding), "match_count": top_k},
+        ).execute()
+        return res.data
+
+    async def transaction(self, func: Callable[[AsyncClient], Awaitable[Any]]) -> Any:
+        sb = await self._client.get_client()
+        async with sb.postgrest.transaction() as tx:
+            try:
+                return await func(tx)
+            except Exception as exc:
+                await tx.rollback()
+                raise DatabaseError("transaction failed") from exc

--- a/python/src/server/services/supabase_client.py
+++ b/python/src/server/services/supabase_client.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import httpx
+from supabase import AsyncClient, AsyncClientOptions, create_async_client
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+
+class SupabaseClientError(Exception):
+    """Raised when the Supabase client fails to initialize or connect."""
+
+
+class SupabaseClient:
+    """Asynchronous Supabase client with connection pooling and retries."""
+
+    def __init__(self) -> None:
+        url = os.getenv("SUPABASE_URL")
+        key = os.getenv("SUPABASE_KEY")
+        if not url or not key:
+            raise SupabaseClientError("Supabase credentials missing")
+        timeout = int(os.getenv("SUPABASE_TIMEOUT", "10"))
+        pool = int(os.getenv("SUPABASE_POOL_SIZE", "10"))
+        self._url = url
+        self._key = key
+        self._session = httpx.AsyncClient(
+            timeout=timeout, limits=httpx.Limits(max_connections=pool)
+        )
+        self._client: Optional[AsyncClient] = None
+
+    async def get_client(self) -> AsyncClient:
+        """Get or create a connected Supabase client with retry logic."""
+        if self._client is not None:
+            return self._client
+        async for attempt in AsyncRetrying(
+            retry=retry_if_exception_type(httpx.HTTPError),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(min=1, max=4),
+        ):
+            with attempt:
+                opts = AsyncClientOptions(httpx_client=self._session)
+                self._client = await create_async_client(self._url, self._key, opts)
+        return self._client
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+        await self._session.aclose()

--- a/python/tests/test_database_service.py
+++ b/python/tests/test_database_service.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from uuid import uuid4
+
+import pytest
+
+from src.server.models.document import Document
+from src.server.models.project import Project
+from src.server.models.query import Query
+from src.server.models.source import Source, SourceType
+from src.server.services import DatabaseError, DatabaseService
+
+
+class FakeExecute:
+    def __init__(self, data: Any) -> None:
+        self._data = data
+
+    async def execute(self) -> Any:
+        return SimpleNamespace(data=self._data)
+
+
+class FakeSelect:
+    def __init__(self, table: "FakeTable", updates: Dict[str, Any] | None = None) -> None:
+        self.table = table
+        self.filters: Dict[str, Any] = {}
+        self.single_mode = False
+        self.updates = updates
+
+    def eq(self, field: str, value: str) -> "FakeSelect":
+        self.filters[field] = value
+        return self
+
+    def single(self) -> "FakeSelect":
+        self.single_mode = True
+        return self
+
+    def select(self, *_: str) -> "FakeSelect":
+        return self
+
+    def delete(self) -> "FakeSelect":
+        self._delete = True
+        return self
+
+    def update(self, updates: Dict[str, Any]) -> "FakeSelect":
+        self.updates = updates
+        return self
+
+    async def execute(self) -> Any:
+        rows = [r for r in self.table.rows if all(str(r[k]) == v for k, v in self.filters.items())]
+        if hasattr(self, "_delete"):
+            self.table.rows = [r for r in self.table.rows if r not in rows]
+            return SimpleNamespace(data=None)
+        if self.updates and rows:
+            rows[0].update(self.updates)
+        if self.single_mode:
+            return SimpleNamespace(data=rows[0] if rows else None)
+        return SimpleNamespace(data=rows)
+
+
+class FakeTable:
+    def __init__(self, rows: List[Dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def insert(self, data: Dict[str, Any]) -> FakeExecute:
+        self.rows.append(data)
+        return FakeExecute([data])
+
+    def select(self, *_: str) -> FakeSelect:
+        return FakeSelect(self)
+
+    def update(self, data: Dict[str, Any]) -> FakeSelect:
+        return FakeSelect(self, updates=data)
+
+    def delete(self) -> FakeSelect:
+        return FakeSelect(self).delete()
+
+
+class FakePostgrest:
+    class Tx:
+        async def __aenter__(self) -> "FakePostgrest.Tx":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: D401
+            return None
+
+        async def rollback(self) -> None:  # noqa: D401
+            return None
+
+    def transaction(self) -> "FakePostgrest.Tx":
+        return FakePostgrest.Tx()
+
+
+class FakeSupabase:
+    def __init__(self) -> None:
+        self.tables: Dict[str, List[Dict[str, Any]]] = {
+            "projects": [],
+            "sources": [],
+            "documents": [],
+            "embeddings": [],
+        }
+        self.postgrest = FakePostgrest()
+
+    def table(self, name: str) -> FakeTable:
+        return FakeTable(self.tables[name])
+
+    def rpc(self, name: str, params: Dict[str, Any]) -> FakeExecute:
+        if name == "match_documents":
+            data = self.tables["documents"][: params["match_count"]]
+        elif name == "match_embeddings":
+            data = self.tables["embeddings"][: params["match_count"]]
+        else:
+            data = []
+        return FakeExecute(data)
+
+
+class FakeClientProvider:
+    def __init__(self) -> None:
+        self.client = FakeSupabase()
+
+    async def get_client(self) -> FakeSupabase:
+        return self.client
+
+
+@pytest.mark.asyncio
+async def test_database_service_flow() -> None:
+    provider = FakeClientProvider()
+    service = DatabaseService(provider)
+
+    project = await service.create_project(Project(id=uuid4(), name="p"))
+    assert (await service.get_project(project.id)).id == project.id
+    assert len(await service.list_projects()) == 1
+    await service.update_project(project.id, {"name": "p2"})
+
+    source = await service.create_source(
+        Source(id=uuid4(), project_id=project.id, type=SourceType.WEB, url="https://x.com")
+    )
+    assert len(await service.list_sources(project.id)) == 1
+
+    doc = await service.create_document(
+        Document(id=uuid4(), source_id=source.id, content="hi")
+    )
+    assert len(await service.vector_search([0.1, 0.2], Query(query_text="x"))) == 1
+
+    assert await service.store_embedding(doc.id, [0.1, 0.2]) is True
+    assert len(await service.similarity_query([0.1, 0.2], 1)) == 1
+
+    assert await service.delete_document(doc.id) is True
+    assert await service.delete_source(source.id) is True
+    assert await service.delete_project(project.id) is True
+
+    async def failing(_: Any) -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(DatabaseError):
+        await service.transaction(failing)

--- a/python/tests/test_migrations.py
+++ b/python/tests/test_migrations.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from src.server.database import MigrationError, run_sql
+
+
+@pytest.mark.asyncio
+async def test_run_sql(tmp_path) -> None:
+    sql_file = tmp_path / "test.sql"
+    sql_file.write_text("SELECT 1; SELECT 2;")
+    executed: List[str] = []
+
+    async def exec_stmt(stmt: str) -> None:
+        executed.append(stmt)
+
+    await run_sql(str(sql_file), exec_stmt)
+    assert executed == ["SELECT 1", "SELECT 2"]
+
+
+@pytest.mark.asyncio
+async def test_run_sql_missing(tmp_path) -> None:
+    with pytest.raises(MigrationError):
+        await run_sql(str(tmp_path / "missing.sql"), lambda _: None)

--- a/python/tests/test_supabase_client.py
+++ b/python/tests/test_supabase_client.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.server.services import SupabaseClient, SupabaseClientError
+
+
+@pytest.mark.asyncio
+async def test_supabase_client_init_and_get(monkeypatch) -> None:
+    monkeypatch.setenv("SUPABASE_URL", "http://example.com")
+    monkeypatch.setenv("SUPABASE_KEY", "secret")
+    monkeypatch.setenv("SUPABASE_TIMEOUT", "5")
+    monkeypatch.setenv("SUPABASE_POOL_SIZE", "2")
+
+    async def fake_create(url: str, key: str, opts: object) -> object:
+        return SimpleNamespace()
+
+    with patch("src.server.services.supabase_client.create_async_client", fake_create):
+        client = SupabaseClient()
+        sb = await client.get_client()
+        assert sb is not None
+        await client.close()
+
+
+def test_supabase_client_missing_env(monkeypatch) -> None:
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_KEY", raising=False)
+    with pytest.raises(SupabaseClientError):
+        SupabaseClient()

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -153,6 +153,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -173,6 +185,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/38/d7f80fd13e6582fb8e0df8c9a653dcc02b03ca34f4d72f34869298c5baf8/h2-4.2.0.tar.gz", hash = "sha256:c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f", size = 2150682, upload-time = "2025-02-02T07:43:51.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/9e/984486f2d0a0bd2b024bf4bc1c62688fcafa9e61991f041fb0e2def4a982/h2-4.2.0-py3-none-any.whl", hash = "sha256:479a53ad425bb29af087f3458a61d30780bc818e4ebcf01f0b536ba916462ed0", size = 60957, upload-time = "2025-02-01T11:02:26.481Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -201,6 +235,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -277,6 +325,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "postgrest"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/3e/1b50568e1f5db0bdced4a82c7887e37326585faef7ca43ead86849cb4861/postgrest-1.1.1.tar.gz", hash = "sha256:f3bb3e8c4602775c75c844a31f565f5f3dd584df4d36d683f0b67d01a86be322", size = 15431, upload-time = "2025-06-23T19:21:34.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/71/188a50ea64c17f73ff4df5196ec1553a8f1723421eb2d1069c73bab47d78/postgrest-1.1.1-py3-none-any.whl", hash = "sha256:98a6035ee1d14288484bfe36235942c5fb2d26af6d8120dfe3efbe007859251a", size = 22366, upload-time = "2025-06-23T19:21:33.637Z" },
 ]
 
 [[package]]
@@ -360,6 +422,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +483,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-socketio" },
+    { name = "supabase" },
     { name = "tenacity" },
     { name = "uvicorn" },
 ]
@@ -432,6 +504,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "python-socketio", extras = ["asgi"], specifier = ">=5.13.0" },
+    { name = "supabase", specifier = ">=2.18.1" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
@@ -442,6 +515,18 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -479,6 +564,20 @@ wheels = [
 ]
 
 [[package]]
+name = "realtime"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ca/e408fbdb6b344bf529c7e8bf020372d21114fe538392c72089462edd26e5/realtime-2.7.0.tar.gz", hash = "sha256:6b9434eeba8d756c8faf94fc0a32081d09f250d14d82b90341170602adbb019f", size = 18860, upload-time = "2025-07-28T18:54:22.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/07/a5c7aef12f9a3497f5ad77157a37915645861e8b23b89b2ad4b0f11b48ad/realtime-2.7.0-py3-none-any.whl", hash = "sha256:d55a278803529a69d61c7174f16563a9cfa5bacc1664f656959694481903d99c", size = 22409, upload-time = "2025-07-28T18:54:21.383Z" },
+]
+
+[[package]]
 name = "simple-websocket"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +587,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -510,6 +618,73 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+]
+
+[[package]]
+name = "storage3"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/e2/280fe75f65e7a3ca680b7843acfc572a63aa41230e3d3c54c66568809c85/storage3-0.12.1.tar.gz", hash = "sha256:32ea8f5eb2f7185c2114a4f6ae66d577722e32503f0a30b56e7ed5c7f13e6b48", size = 10198, upload-time = "2025-08-05T18:09:11.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3b/c5f8709fc5349928e591fee47592eeff78d29a7d75b097f96a4e01de028d/storage3-0.12.1-py3-none-any.whl", hash = "sha256:9da77fd4f406b019fdcba201e9916aefbf615ef87f551253ce427d8136459a34", size = 18420, upload-time = "2025-08-05T18:09:10.365Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "postgrest" },
+    { name = "realtime" },
+    { name = "storage3" },
+    { name = "supabase-auth" },
+    { name = "supabase-functions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/d2/3b135af55dd5788bd47875bb81f99c870054b990c030e51fd641a61b10b5/supabase-2.18.1.tar.gz", hash = "sha256:205787b1fbb43d6bc997c06fe3a56137336d885a1b56ec10f0012f2a2905285d", size = 11549, upload-time = "2025-08-12T19:02:27.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/33/0e0062fea22cfe01d466dee83f56b3ed40c89bdcbca671bafeba3fe86b92/supabase-2.18.1-py3-none-any.whl", hash = "sha256:4fdd7b7247178a847f97ecd34f018dcb4775e487c8ff46b1208a01c933691fe9", size = 18683, upload-time = "2025-08-12T19:02:26.68Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e9/3d6f696a604752803b9e389b04d454f4b26a29b5d155b257fea4af8dc543/supabase_auth-2.12.3.tar.gz", hash = "sha256:8d3b67543f3b27f5adbfe46b66990424c8504c6b08c1141ec572a9802761edc2", size = 38430, upload-time = "2025-07-04T06:49:22.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/a6/4102d5fa08a8521d9432b4d10bb58fedbd1f92b211d1b45d5394f5cb9021/supabase_auth-2.12.3-py3-none-any.whl", hash = "sha256:15c7580e1313d30ffddeb3221cb3cdb87c2a80fd220bf85d67db19cd1668435b", size = 44417, upload-time = "2025-07-04T06:49:21.351Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "strenum" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e4/6df7cd4366396553449e9907c745862ebf010305835b2bac99933dd7db9d/supabase_functions-0.10.1.tar.gz", hash = "sha256:4779d33a1cc3d4aea567f586b16d8efdb7cddcd6b40ce367c5fb24288af3a4f1", size = 5025, upload-time = "2025-06-23T18:26:12.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/06/060118a1e602c9bda8e4bf950bd1c8b5e1542349f2940ec57541266fabe1/supabase_functions-0.10.1-py3-none-any.whl", hash = "sha256:1db85e20210b465075aacee4e171332424f7305f9903c5918096be1423d6fcc5", size = 8275, upload-time = "2025-06-23T18:26:10.387Z" },
 ]
 
 [[package]]
@@ -553,6 +728,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Supabase client with pooled async connections and retry logic
- implement database service layer with CRUD, pgvector search, and transactions
- add SQL migration runner
- cover new services with tests

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a25d805efc8322876043702438b99d