### PR TITLE
feat(mcp): add SSE-based MCP server with project tools

### DIFF
--- a/python/src/mcp/__init__.py
+++ b/python/src/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""MCP package providing server and tools."""
+
+from __future__ import annotations
+
+
+class ToolExecutionError(Exception):
+    """Raised when a tool fails to execute."""
+
+
+__all__ = ["ToolExecutionError"]

--- a/python/src/mcp/mcp_server.py
+++ b/python/src/mcp/mcp_server.py
@@ -1,0 +1,100 @@
+"""HTTP MCP server with SSE transport."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from src.common.service import create_service
+
+from . import ToolExecutionError
+from .tools import TOOLS
+from .transport.sse import SSETransport
+
+API_KEY = os.getenv("MCP_API_KEY", "")
+RATE_LIMIT: Dict[str, list[float]] = {}
+MAX_REQUESTS = 10
+WINDOW_SECONDS = 60.0
+
+
+class AuthenticationError(Exception):
+    """Raised when authentication fails."""
+
+
+class RateLimitError(Exception):
+    """Raised when rate limit is exceeded."""
+
+
+app = create_service()
+transport = SSETransport()
+
+
+@app.exception_handler(AuthenticationError)
+async def _auth_error(_: Request, exc: AuthenticationError) -> JSONResponse:
+    return JSONResponse(status_code=401, content={"detail": str(exc)})
+
+
+@app.exception_handler(RateLimitError)
+async def _limit_error(_: Request, exc: RateLimitError) -> JSONResponse:
+    return JSONResponse(status_code=429, content={"detail": str(exc)})
+
+
+def _check_auth(request: Request) -> None:
+    token = request.headers.get("Authorization", "")
+    if token != f"Bearer {API_KEY}":
+        raise AuthenticationError("Invalid API key")
+
+
+def _check_rate_limit(request: Request) -> None:
+    key = request.client.host
+    now = time.time()
+    window = RATE_LIMIT.setdefault(key, [])
+    window[:] = [t for t in window if now - t < WINDOW_SECONDS]
+    if len(window) >= MAX_REQUESTS:
+        raise RateLimitError("Rate limit exceeded")
+    window.append(now)
+
+
+@app.get("/sse")
+async def sse_endpoint(request: Request, client_id: str, close: bool = False) -> Any:
+    _check_auth(request)
+    _check_rate_limit(request)
+    return await transport.connect(client_id, close=close)
+
+
+class RPCRequest(BaseModel):  # We'll need to import BaseModel at top
+    id: str = Field(..., min_length=1)
+    method: str = Field(..., min_length=1)
+    params: Dict[str, Any] = Field(default_factory=dict)
+    client_id: str | None = None
+
+
+@app.post("/rpc")
+async def rpc_endpoint(req: RPCRequest, request: Request) -> JSONResponse:
+    _check_auth(request)
+    _check_rate_limit(request)
+    if req.method == "tools/list":
+        result = {"tools": list(TOOLS.keys())}
+    else:
+        tool = TOOLS.get(req.method)
+        if not tool:
+            raise HTTPException(status_code=404, detail="Method not found")
+        try:
+            result = await tool(req.params)
+        except ToolExecutionError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    response = {"jsonrpc": "2.0", "id": req.id, "result": result}
+    if req.client_id:
+        await transport.send(req.client_id, response)
+    return JSONResponse(response)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("src.mcp.mcp_server:app", host="0.0.0.0", port=8051)

--- a/python/src/mcp/tools/__init__.py
+++ b/python/src/mcp/tools/__init__.py
@@ -1,0 +1,11 @@
+"""Tool registry for MCP server."""
+
+from __future__ import annotations
+
+from .project_tools import TOOLS as project_tools
+from .rag_tools import TOOLS as rag_tools
+from .source_tools import TOOLS as source_tools
+
+TOOLS = {**project_tools, **source_tools, **rag_tools}
+
+__all__ = ["TOOLS"]

--- a/python/src/mcp/tools/project_tools.py
+++ b/python/src/mcp/tools/project_tools.py
@@ -1,0 +1,65 @@
+"""Project management tools for MCP."""
+
+from __future__ import annotations
+
+from typing import Dict
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from .. import ToolExecutionError
+
+
+class Project(BaseModel):
+    """Simple project model."""
+
+    id: str
+    name: str
+    status: str = "new"
+
+
+PROJECTS: Dict[str, Project] = {}
+
+
+class CreateProjectRequest(BaseModel):
+    """Request model for creating a project."""
+
+    name: str = Field(..., min_length=1, max_length=100)
+
+
+async def create_project(params: dict) -> dict:
+    """Create a new project."""
+
+    data = CreateProjectRequest(**params)
+    project = Project(id=str(uuid4()), name=data.name)
+    PROJECTS[project.id] = project
+    return project.model_dump()
+
+
+async def list_projects(_: dict) -> dict:
+    """List all projects."""
+
+    return {"projects": [p.model_dump() for p in PROJECTS.values()]}
+
+
+class StatusRequest(BaseModel):
+    """Request model for retrieving project status."""
+
+    project_id: str = Field(..., min_length=1)
+
+
+async def get_project_status(params: dict) -> dict:
+    """Get information about a project."""
+
+    data = StatusRequest(**params)
+    project = PROJECTS.get(data.project_id)
+    if not project:
+        raise ToolExecutionError("Project not found")
+    return project.model_dump()
+
+
+TOOLS = {
+    "list_projects": list_projects,
+    "create_project": create_project,
+    "get_project_status": get_project_status,
+}

--- a/python/src/mcp/tools/rag_tools.py
+++ b/python/src/mcp/tools/rag_tools.py
@@ -1,0 +1,29 @@
+"""Retrieval-Augmented Generation tools."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .. import ToolExecutionError
+from .source_tools import PROJECT_SOURCES
+
+
+class QueryRequest(BaseModel):
+    """Request model for knowledge queries."""
+
+    project_id: str = Field(..., min_length=1)
+    query: str = Field(..., min_length=1, max_length=200)
+
+
+async def query_knowledge(params: dict) -> dict:
+    """Query the knowledge base for a project."""
+
+    data = QueryRequest(**params)
+    sources = PROJECT_SOURCES.get(data.project_id)
+    if not sources:
+        raise ToolExecutionError("No sources for project")
+    matches = [s for s in sources if data.query.lower() in s.lower()]
+    return {"matches": matches}
+
+
+TOOLS = {"query_knowledge": query_knowledge}

--- a/python/src/mcp/tools/source_tools.py
+++ b/python/src/mcp/tools/source_tools.py
@@ -1,0 +1,32 @@
+"""Knowledge source management tools."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+from .. import ToolExecutionError
+from .project_tools import PROJECTS
+
+PROJECT_SOURCES: Dict[str, List[str]] = {}
+
+
+class AddSourceRequest(BaseModel):
+    """Request model for adding a source to a project."""
+
+    project_id: str = Field(..., min_length=1)
+    source: str = Field(..., min_length=1, max_length=200)
+
+
+async def add_source(params: dict) -> dict:
+    """Add a knowledge source to a project."""
+
+    data = AddSourceRequest(**params)
+    if data.project_id not in PROJECTS:
+        raise ToolExecutionError("Project not found")
+    PROJECT_SOURCES.setdefault(data.project_id, []).append(data.source)
+    return {"sources": PROJECT_SOURCES[data.project_id]}
+
+
+TOOLS = {"add_source": add_source}

--- a/python/src/mcp/transport/sse.py
+++ b/python/src/mcp/transport/sse.py
@@ -1,0 +1,38 @@
+"""Simple SSE transport implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Dict
+
+from fastapi.responses import StreamingResponse
+
+
+class SSETransport:
+    """Manage Server-Sent Events connections."""
+
+    def __init__(self) -> None:
+        self._clients: Dict[str, asyncio.Queue[str]] = {}
+
+    async def connect(self, client_id: str, close: bool = False) -> StreamingResponse:
+        queue: asyncio.Queue[str] = asyncio.Queue()
+        self._clients[client_id] = queue
+
+        async def event_generator() -> AsyncIterator[bytes]:
+            try:
+                yield b"data: connected\n\n"
+                if close:
+                    return
+                while True:
+                    data = await queue.get()
+                    yield f"data: {data}\n\n".encode()
+            finally:
+                self._clients.pop(client_id, None)
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+    async def send(self, client_id: str, message: dict) -> None:
+        if client_id in self._clients:
+            await self._clients[client_id].put(json.dumps(message))

--- a/python/tests/test_mcp_server.py
+++ b/python/tests/test_mcp_server.py
@@ -1,0 +1,87 @@
+import os
+from typing import Set
+
+import asyncio
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Set API key before importing the app
+os.environ["MCP_API_KEY"] = "test-key"
+from src.mcp.mcp_server import app  # noqa: E402
+from src.mcp.tools.project_tools import PROJECTS  # noqa: E402
+from src.mcp.tools.source_tools import PROJECT_SOURCES  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_sse_connect() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer test-key"}
+        res = await client.get("/sse?client_id=abc&close=1", headers=headers)
+        assert res.status_code == 200
+        assert res.headers["content-type"].startswith("text/event-stream")
+        assert res.text.startswith("data: connected")
+
+
+@pytest.mark.asyncio
+async def test_tool_workflow() -> None:
+    PROJECTS.clear()
+    PROJECT_SOURCES.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer test-key"}
+        res = await client.post(
+            "/rpc", headers=headers, json={"id": "1", "method": "tools/list"}
+        )
+        tools: Set[str] = set(res.json()["result"]["tools"])
+        assert {
+            "list_projects",
+            "create_project",
+            "get_project_status",
+            "add_source",
+            "query_knowledge",
+        } <= tools
+        res = await client.post(
+            "/rpc",
+            headers=headers,
+            json={"id": "2", "method": "create_project", "params": {"name": "demo"}},
+        )
+        project_id = res.json()["result"]["id"]
+        res = await client.post(
+            "/rpc",
+            headers=headers,
+            json={
+                "id": "3",
+                "method": "add_source",
+                "params": {"project_id": project_id, "source": "doc"},
+            },
+        )
+        assert "doc" in res.json()["result"]["sources"]
+        res = await client.post(
+            "/rpc",
+            headers=headers,
+            json={
+                "id": "4",
+                "method": "query_knowledge",
+                "params": {"project_id": project_id, "query": "doc"},
+            },
+        )
+        assert res.json()["result"]["matches"] == ["doc"]
+        res = await client.post(
+            "/rpc",
+            headers=headers,
+            json={
+                "id": "5",
+                "method": "get_project_status",
+                "params": {"project_id": project_id},
+            },
+        )
+        assert res.json()["result"]["name"] == "demo"
+
+
+@pytest.mark.asyncio
+async def test_auth_required() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post("/rpc", json={"id": "1", "method": "tools/list"})
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- implement FastAPI MCP server with SSE transport, auth, and rate limiting
- add project, source, and RAG tools with JSON-RPC discovery
- cover MCP workflow and SSE endpoint with tests

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a261ded0ec8322b0712f02cdfb5656