### PR TITLE
feat: add database routes and health checks

### DIFF
--- a/python/src/server/main.py
+++ b/python/src/server/main.py
@@ -9,12 +9,13 @@ application to enable real-time features.
 from __future__ import annotations
 
 import sys
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 import socketio
 
 from .config import settings
+from .routes import health, projects, sources, documents
 
 
 class HealthCheckError(Exception):
@@ -49,14 +50,10 @@ async def rate_limit() -> None:
     return None
 
 
-@api.get("/health")
-async def health(_: None = Depends(rate_limit)) -> dict[str, str]:
-    """Simple health check endpoint."""
-    try:
-        return {"status": "ok"}
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("health check failed")
-        raise HTTPException(status_code=503, detail="unhealthy") from exc
+api.include_router(health.router, dependencies=[Depends(rate_limit)])
+api.include_router(projects.router, dependencies=[Depends(rate_limit)])
+api.include_router(sources.router, dependencies=[Depends(rate_limit)])
+api.include_router(documents.router, dependencies=[Depends(rate_limit)])
 
 
 @sio.event

--- a/python/src/server/routes/__init__.py
+++ b/python/src/server/routes/__init__.py
@@ -1,0 +1,21 @@
+"""FastAPI route dependencies and exports."""
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from fastapi import Depends
+
+from ..services.database import DatabaseService
+from ..services.supabase_client import SupabaseClient
+
+
+async def get_database_service() -> AsyncGenerator[DatabaseService, None]:
+    """Provide a DatabaseService instance per request."""
+    client = SupabaseClient()
+    service = DatabaseService(client)
+    try:
+        yield service
+    finally:
+        await client.close()
+
+
+__all__ = ["get_database_service"]

--- a/python/src/server/routes/documents.py
+++ b/python/src/server/routes/documents.py
@@ -1,0 +1,90 @@
+"""Document CRUD and search routes."""
+from __future__ import annotations
+
+from typing import List, Optional, Dict, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import BaseModel
+
+from ..models.base import ResponseModel, ResponseStatus
+from ..models.document import Document
+from ..models.query import Query
+from ..services.database import DatabaseError, DatabaseService
+from . import get_database_service
+
+
+class DocumentUpdate(BaseModel):
+    content: Optional[str] = None
+    embeddings: Optional[List[float]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class SearchRequest(BaseModel):
+    embedding: List[float]
+    query: Query
+
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+@router.post("/", response_model=ResponseModel[Document], status_code=status.HTTP_201_CREATED)
+async def create_document(
+    doc: Document, db: DatabaseService = Depends(get_database_service)
+) -> ResponseModel[Document]:
+    """Create a document."""
+    try:
+        created = await db.create_document(doc)
+        return ResponseModel(status=ResponseStatus.SUCCESS, data=created)
+    except DatabaseError as exc:
+        raise HTTPException(status_code=500, detail="create failed") from exc
+
+
+@router.get("/{doc_id}", response_model=ResponseModel[Document])
+async def get_document(
+    doc_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[Document]:
+    """Retrieve a document."""
+    doc = await db.get_document(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="document not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=doc)
+
+
+@router.put("/{doc_id}", response_model=ResponseModel[Document])
+async def update_document(
+    doc_id: UUID = Path(...),
+    data: DocumentUpdate | None = None,
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[Document]:
+    """Update a document."""
+    payload = data.model_dump(exclude_none=True) if data else {}
+    updated = await db.update_document(doc_id, payload)
+    if not updated:
+        raise HTTPException(status_code=404, detail="document not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=updated)
+
+
+@router.delete("/{doc_id}", response_model=ResponseModel[dict[str, bool]])
+async def delete_document(
+    doc_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[dict[str, bool]]:
+    """Delete a document."""
+    ok = await db.delete_document(doc_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="document not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data={"deleted": True})
+
+
+@router.post("/search", response_model=ResponseModel[List[Document]])
+async def search_documents(
+    req: SearchRequest, db: DatabaseService = Depends(get_database_service)
+) -> ResponseModel[List[Document]]:
+    """Vector search for documents."""
+    try:
+        results = await db.vector_search(req.embedding, req.query)
+        return ResponseModel(status=ResponseStatus.SUCCESS, data=results)
+    except DatabaseError as exc:
+        raise HTTPException(status_code=500, detail="search failed") from exc

--- a/python/src/server/routes/health.py
+++ b/python/src/server/routes/health.py
@@ -1,0 +1,22 @@
+"""Health check route."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..models.base import ResponseModel, ResponseStatus
+from ..services.database import DatabaseError, DatabaseService
+from . import get_database_service
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=ResponseModel[dict[str, str]])
+async def health(
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[dict[str, str]]:
+    """Check database connectivity and report service status."""
+    try:
+        await db.list_projects()
+        return ResponseModel(status=ResponseStatus.SUCCESS, data={"database": "ok"})
+    except DatabaseError as exc:
+        raise HTTPException(status_code=503, detail="database unavailable") from exc

--- a/python/src/server/routes/projects.py
+++ b/python/src/server/routes/projects.py
@@ -1,0 +1,82 @@
+"""Project CRUD routes."""
+from __future__ import annotations
+
+from typing import List, Optional, Dict, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import BaseModel, Field
+
+from ..models.base import ResponseModel, ResponseStatus
+from ..models.project import Project, ProjectStatus
+from ..services.database import DatabaseError, DatabaseService
+from . import get_database_service
+
+
+class ProjectUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=500)
+    status: Optional[ProjectStatus] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.post("/", response_model=ResponseModel[Project], status_code=status.HTTP_201_CREATED)
+async def create_project(
+    project: Project, db: DatabaseService = Depends(get_database_service)
+) -> ResponseModel[Project]:
+    """Create a new project."""
+    try:
+        created = await db.create_project(project)
+        return ResponseModel(status=ResponseStatus.SUCCESS, data=created)
+    except DatabaseError as exc:
+        raise HTTPException(status_code=500, detail="create failed") from exc
+
+
+@router.get("/", response_model=ResponseModel[List[Project]])
+async def list_projects(
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[List[Project]]:
+    """List all projects."""
+    projects = await db.list_projects()
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=projects)
+
+
+@router.get("/{project_id}", response_model=ResponseModel[Project])
+async def get_project(
+    project_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[Project]:
+    """Retrieve a project by ID."""
+    project = await db.get_project(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=project)
+
+
+@router.put("/{project_id}", response_model=ResponseModel[Project])
+async def update_project(
+    project_id: UUID = Path(...),
+    data: ProjectUpdate | None = None,
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[Project]:
+    """Update project fields."""
+    payload = data.model_dump(exclude_none=True) if data else {}
+    updated = await db.update_project(project_id, payload)
+    if not updated:
+        raise HTTPException(status_code=404, detail="project not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=updated)
+
+
+@router.delete("/{project_id}", response_model=ResponseModel[dict[str, bool]])
+async def delete_project(
+    project_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[dict[str, bool]]:
+    """Delete a project."""
+    ok = await db.delete_project(project_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="project not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data={"deleted": True})

--- a/python/src/server/routes/sources.py
+++ b/python/src/server/routes/sources.py
@@ -1,0 +1,83 @@
+"""Source CRUD routes."""
+from __future__ import annotations
+
+from typing import List, Optional, Dict, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import BaseModel
+
+from ..models.base import ResponseModel, ResponseStatus
+from ..models.source import Source, SourceStatus, SourceType
+from ..services.database import DatabaseError, DatabaseService
+from . import get_database_service
+
+
+class SourceUpdate(BaseModel):
+    type: Optional[SourceType] = None
+    url: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    status: Optional[SourceStatus] = None
+
+
+router = APIRouter(prefix="/sources", tags=["sources"])
+
+
+@router.post("/", response_model=ResponseModel[Source], status_code=status.HTTP_201_CREATED)
+async def create_source(
+    source: Source, db: DatabaseService = Depends(get_database_service)
+) -> ResponseModel[Source]:
+    """Create a new source."""
+    try:
+        created = await db.create_source(source)
+        return ResponseModel(status=ResponseStatus.SUCCESS, data=created)
+    except DatabaseError as exc:
+        raise HTTPException(status_code=500, detail="create failed") from exc
+
+
+@router.get("/project/{project_id}", response_model=ResponseModel[List[Source]])
+async def list_sources(
+    project_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[List[Source]]:
+    """List sources for a project."""
+    sources = await db.list_sources(project_id)
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=sources)
+
+
+@router.get("/{source_id}", response_model=ResponseModel[Source])
+async def get_source(
+    source_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[Source]:
+    """Retrieve a source by ID."""
+    source = await db.get_source(source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="source not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=source)
+
+
+@router.put("/{source_id}", response_model=ResponseModel[Source])
+async def update_source(
+    source_id: UUID = Path(...),
+    data: SourceUpdate | None = None,
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[Source]:
+    """Update source fields."""
+    payload = data.model_dump(exclude_none=True) if data else {}
+    updated = await db.update_source(source_id, payload)
+    if not updated:
+        raise HTTPException(status_code=404, detail="source not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data=updated)
+
+
+@router.delete("/{source_id}", response_model=ResponseModel[dict[str, bool]])
+async def delete_source(
+    source_id: UUID = Path(...),
+    db: DatabaseService = Depends(get_database_service),
+) -> ResponseModel[dict[str, bool]]:
+    """Delete a source."""
+    ok = await db.delete_source(source_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="source not found")
+    return ResponseModel(status=ResponseStatus.SUCCESS, data={"deleted": True})

--- a/python/tests/test_routes.py
+++ b/python/tests/test_routes.py
@@ -1,0 +1,206 @@
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from uuid import uuid4
+
+from src.server import app
+from src.server.main import api
+from src.server.routes import get_database_service
+from src.server.services.database import DatabaseService
+from src.server.models.project import Project, ProjectStatus
+from src.server.models.source import Source, SourceStatus, SourceType
+from src.server.models.document import Document
+from src.server.models.query import Query
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.projects = {}
+        self.sources = {}
+        self.documents = {}
+
+    async def create_project(self, project: Project) -> Project:
+        self.projects[project.id] = project
+        return project
+
+    async def list_projects(self):
+        return list(self.projects.values())
+
+    async def get_project(self, pid):
+        return self.projects.get(pid)
+
+    async def update_project(self, pid, data):
+        proj = self.projects.get(pid)
+        if not proj:
+            return None
+        new_data = proj.model_dump()
+        new_data.update(data)
+        proj = Project(**new_data)
+        self.projects[pid] = proj
+        return proj
+
+    async def delete_project(self, pid):
+        return self.projects.pop(pid, None) is not None
+
+    async def create_source(self, source: Source) -> Source:
+        self.sources[source.id] = source
+        return source
+
+    async def list_sources(self, project_id):
+        return [s for s in self.sources.values() if s.project_id == project_id]
+
+    async def get_source(self, sid):
+        return self.sources.get(sid)
+
+    async def update_source(self, sid, data):
+        src = self.sources.get(sid)
+        if not src:
+            return None
+        new_data = src.model_dump()
+        new_data.update(data)
+        src = Source(**new_data)
+        self.sources[sid] = src
+        return src
+
+    async def delete_source(self, sid):
+        return self.sources.pop(sid, None) is not None
+
+    async def create_document(self, doc: Document) -> Document:
+        self.documents[doc.id] = doc
+        return doc
+
+    async def get_document(self, did):
+        return self.documents.get(did)
+
+    async def update_document(self, did, data):
+        doc = self.documents.get(did)
+        if not doc:
+            return None
+        new_data = doc.model_dump()
+        new_data.update(data)
+        doc = Document(**new_data)
+        self.documents[did] = doc
+        return doc
+
+    async def delete_document(self, did):
+        return self.documents.pop(did, None) is not None
+
+    async def vector_search(self, embedding, query: Query):
+        return list(self.documents.values())[: query.match_count]
+
+
+@pytest_asyncio.fixture
+async def client():
+    fake_db = FakeDB()
+
+    async def _get_db():
+        return fake_db
+
+    api.dependency_overrides[get_database_service] = _get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    api.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_project_crud_flow(client: AsyncClient) -> None:
+    pid = uuid4()
+    proj = {
+        "id": str(pid),
+        "name": "proj",
+        "description": "d",
+        "status": ProjectStatus.ACTIVE,
+        "settings": {},
+    }
+    res = await client.post("/projects/", json=proj)
+    assert res.status_code == 201
+    res = await client.get("/projects/")
+    assert res.json()["data"][0]["id"] == str(pid)
+    res = await client.put(f"/projects/{pid}", json={"name": "p2"})
+    assert res.json()["data"]["name"] == "p2"
+    res = await client.delete(f"/projects/{pid}")
+    assert res.json()["data"]["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_source_crud_flow(client: AsyncClient) -> None:
+    pid = uuid4()
+    sid = uuid4()
+    proj = {
+        "id": str(pid),
+        "name": "proj",
+        "description": "d",
+        "status": ProjectStatus.ACTIVE,
+        "settings": {},
+    }
+    await client.post("/projects/", json=proj)
+    source = {
+        "id": str(sid),
+        "project_id": str(pid),
+        "type": SourceType.WEB,
+        "url": "https://example.com",
+        "metadata": {},
+        "status": SourceStatus.PENDING,
+    }
+    res = await client.post("/sources/", json=source)
+    assert res.status_code == 201
+    res = await client.get(f"/sources/project/{pid}")
+    assert res.json()["data"][0]["id"] == str(sid)
+    res = await client.put(f"/sources/{sid}", json={"status": SourceStatus.READY})
+    assert res.json()["data"]["status"] == SourceStatus.READY
+    res = await client.delete(f"/sources/{sid}")
+    assert res.json()["data"]["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_document_crud_and_search(client: AsyncClient) -> None:
+    pid, sid, did = uuid4(), uuid4(), uuid4()
+    proj = {
+        "id": str(pid),
+        "name": "proj",
+        "description": "d",
+        "status": ProjectStatus.ACTIVE,
+        "settings": {},
+    }
+    await client.post("/projects/", json=proj)
+    source = {
+        "id": str(sid),
+        "project_id": str(pid),
+        "type": SourceType.WEB,
+        "url": "https://example.com",
+        "metadata": {},
+        "status": SourceStatus.PENDING,
+    }
+    await client.post("/sources/", json=source)
+    doc = {
+        "id": str(did),
+        "source_id": str(sid),
+        "content": "hello",
+        "embeddings": [0.1, 0.2],
+        "metadata": {},
+    }
+    res = await client.post("/documents/", json=doc)
+    assert res.status_code == 201
+    res = await client.get(f"/documents/{did}")
+    assert res.json()["data"]["content"] == "hello"
+    res = await client.put(f"/documents/{did}", json={"content": "hi"})
+    assert res.json()["data"]["content"] == "hi"
+    search_req = {
+        "embedding": [0.1, 0.2],
+        "query": {"query_text": "hello", "match_count": 5, "filters": {}, "threshold": 0.5},
+    }
+    res = await client.post("/documents/search", json=search_req)
+    assert res.json()["data"][0]["id"] == str(did)
+    res = await client.delete(f"/documents/{did}")
+    assert res.json()["data"]["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_database_service_lifecycle(monkeypatch) -> None:
+    monkeypatch.setenv("SUPABASE_URL", "http://example.com")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
+    agen = get_database_service()
+    service = await agen.__anext__()
+    assert isinstance(service, DatabaseService)
+    await agen.aclose()

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -2,17 +2,31 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.server import app
-from src.server.main import connect, disconnect
+from src.server.main import api, connect, disconnect
+from src.server.routes import get_database_service
 
 
 @pytest.mark.asyncio
 async def test_health_and_cors() -> None:
     """Health endpoint responds and includes CORS headers."""
+    async def _get_db():  # pragma: no cover - simple stub
+        class Dummy:
+            async def list_projects(self):
+                return []
+
+        return Dummy()
+
+    api.dependency_overrides[get_database_service] = _get_db
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         res = await client.get("/health", headers={"Origin": "http://localhost:3000"})
+    api.dependency_overrides.clear()
     assert res.status_code == 200
-    assert res.json() == {"status": "ok"}
+    assert res.json() == {
+        "status": "success",
+        "data": {"database": "ok"},
+        "error": None,
+    }
     assert res.headers["access-control-allow-origin"] == "http://localhost:3000"
 
 


### PR DESCRIPTION
## Summary
- expose DatabaseService through FastAPI routers for projects, sources, and documents
- add improved health check endpoint and route dependencies
- include tests for new API routes and database service lifecycle

## Testing
- `pytest tests/test_server.py tests/test_routes.py --cov=src/server/routes --cov-branch`


------
https://chatgpt.com/codex/tasks/task_e_68a2a1704e708322b3f117f8a08f4aea