### PR TITLE
Refine embedding error handling and tests

### DIFF
--- a/python/src/server/routes/documents.py
+++ b/python/src/server/routes/documents.py
@@ -24,7 +24,10 @@ from ..models.base import ResponseModel, ResponseStatus
 from ..models.document import Document
 from ..models.query import Query
 from ..services.database import DatabaseError, DatabaseService
-from ..services.embedding import generate_embedding
+from ..services.embedding import (
+    EmbeddingProcessingError,
+    generate_embedding,
+)
 from ..socket import broadcast_upload_progress, BroadcastError
 from . import get_database_service
 from loguru import logger
@@ -99,7 +102,7 @@ async def _process_embedding(
             )
         except BroadcastError:
             logger.warning("upload progress broadcast failed", doc_id=str(doc_id))
-    except Exception as exc:  # noqa: BLE001
+    except EmbeddingProcessingError as exc:
         INGESTION_PROGRESS[doc_id] = {"status": "failed", "error": str(exc)}
         try:
             await broadcast_upload_progress(

--- a/python/src/server/services/embedding.py
+++ b/python/src/server/services/embedding.py
@@ -11,7 +11,11 @@ from tenacity import AsyncRetrying, stop_after_attempt, wait_fixed
 EMBEDDING_API_KEY = os.getenv("EMBEDDING_API_KEY", "")
 
 
-class EmbeddingGenerationError(Exception):
+class EmbeddingProcessingError(Exception):
+    """Base error for embedding processing failures."""
+
+
+class EmbeddingGenerationError(EmbeddingProcessingError):
     """Raised when embedding generation fails."""
 
 
@@ -21,6 +25,8 @@ async def _hash_text(text: str) -> List[float]:
 
 
 async def generate_embedding(text: str) -> List[float]:
+    if not text:
+        raise EmbeddingProcessingError("text must not be empty")
     async for attempt in AsyncRetrying(stop=stop_after_attempt(3), wait=wait_fixed(1)):
         with attempt:
             try:


### PR DESCRIPTION
## Summary
- add EmbeddingProcessingError and ensure generate_embedding validates input
- handle EmbeddingProcessingError in document embedding process and propagate other failures
- test embedding error paths and unexpected exception propagation

## Testing
- `pytest python/tests/test_routes.py::test_process_embedding_handles_expected_error -q`
- `pytest python/tests/test_routes.py::test_process_embedding_propagates_unexpected_exceptions -q`


------
https://chatgpt.com/codex/tasks/task_e_68a375208a3c8322a665053cf97dddd2