### PR TITLE
feat: enforce jwt validation for socket connections

### DIFF
--- a/python/tests/test_socket_events.py
+++ b/python/tests/test_socket_events.py
@@ -1,23 +1,32 @@
 import asyncio
-import asyncio
+from typing import Tuple
+
+import pytest
 import socketio
 import uvicorn
 
+from server.auth.jwt import JWTService
 from server.main import app
 from server.socket import broadcast_upload_progress, broadcast_search_completed
 
 
-def test_realtime_events():
-    async def runner() -> None:
-        config = uvicorn.Config(app, host="127.0.0.1", port=9000, log_level="warning")
-        server = uvicorn.Server(config)
-        server_task = asyncio.create_task(server.serve())
-        await asyncio.sleep(0.3)
+async def _serve(port: int) -> Tuple[uvicorn.Server, asyncio.Task]:
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    await asyncio.sleep(0.3)
+    return server, task
 
+
+def test_realtime_events() -> None:
+    async def runner() -> None:
+        server, server_task = await _serve(9000)
+        jwt = JWTService()
+        t1 = jwt.create_token("u1", "user")
+        t2 = jwt.create_token("u2", "user")
         client1 = socketio.AsyncClient()
         client2 = socketio.AsyncClient()
-
-        await client1.connect("http://127.0.0.1:9000?user_id=u1")
+        await client1.connect(f"http://127.0.0.1:9000?user_id=u1&token={t1}")
         await client1.emit("project_join", {"project_id": "p1"})
 
         join_future: asyncio.Future = asyncio.Future()
@@ -27,9 +36,8 @@ def test_realtime_events():
             if not join_future.done():
                 join_future.set_result(data)
 
-        await client2.connect("http://127.0.0.1:9000?user_id=u2")
+        await client2.connect(f"http://127.0.0.1:9000?user_id=u2&token={t2}")
         await client2.emit("project_join", {"project_id": "p1"})
-
         join_data = await asyncio.wait_for(join_future, 1)
         assert join_data["user_id"] == "u2"
 
@@ -69,5 +77,29 @@ def test_realtime_events():
         await client1.disconnect()
         server.should_exit = True
         await server_task
+
+    asyncio.run(runner())
+
+
+jwt_service = JWTService()
+VALID_TOKEN = jwt_service.create_token("u1", "user")
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "user_id=u1",
+        "user_id=u1&token=bad",
+        f"user_id=u2&token={VALID_TOKEN}",
+    ],
+)
+def test_invalid_connections(query: str) -> None:
+    async def runner() -> None:
+        server, task = await _serve(9001)
+        client = socketio.AsyncClient()
+        with pytest.raises(socketio.exceptions.ConnectionError):
+            await client.connect(f"http://127.0.0.1:9001?{query}")
+        server.should_exit = True
+        await task
 
     asyncio.run(runner())


### PR DESCRIPTION
## Summary
- require JWT token for socket connections and validate against user ID
- add tests covering valid and invalid socket connection attempts

## Testing
- ⚠️ `pytest -q` *(missing dependencies)*
- ✅ `pytest python/tests/test_socket_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3756370bc8322b5e94b9e00f90f18