### PR TITLE
[Monitoring] Add Prometheus metrics endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,22 @@ services:
       retries: 3
       start_period: 40s
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: Archon-Prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    networks:
+      - app-network
+    depends_on:
+      - archon-server
+      - archon-mcp
+      - archon-agents
+
   # Frontend
   frontend:
     build: ./archon-ui-main

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -7,3 +7,15 @@ scrape_configs:
       - targets:
           - '${TEI_METRICS_ENDPOINT:-tei:9090}'
           - '${VLLM_METRICS_ENDPOINT:-vllm:9090}'
+  - job_name: 'archon-server'
+    static_configs:
+      - targets:
+          - 'archon-server:8080'
+  - job_name: 'archon-mcp'
+    static_configs:
+      - targets:
+          - 'archon-mcp:8051'
+  - job_name: 'archon-agents'
+    static_configs:
+      - targets:
+          - 'archon-agents:8052'

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "uvicorn>=0.35.0",
     "pyjwt>=2.10.1",
     "PyPDF2>=3.0.1",
+    "prometheus-client>=0.21.0",
 ]
 
 [dependency-groups]

--- a/python/requirements.minimal.txt
+++ b/python/requirements.minimal.txt
@@ -14,3 +14,4 @@ tenacity>=9.1.2
 uvicorn>=0.35.0
 pyjwt>=2.10.1
 PyPDF2>=3.0.1
+prometheus-client>=0.21.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,6 +14,7 @@ tenacity>=9.1.2
 uvicorn>=0.35.0
 pyjwt>=2.10.1
 PyPDF2>=3.0.1
+prometheus-client>=0.21.0
 
 # Sub-dependencies (automatically resolved but listed for transparency)
 annotated-types>=0.7.0

--- a/python/src/agents/main.py
+++ b/python/src/agents/main.py
@@ -10,7 +10,7 @@ class TaskRequest(BaseModel):
     task: str = Field(..., min_length=1, max_length=100)
 
 
-app = create_service()
+app = create_service("agents")
 
 
 @app.post("/run")

--- a/python/src/common/metrics.py
+++ b/python/src/common/metrics.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+from typing import Awaitable, Callable
+
+from fastapi import FastAPI, Request, Response
+from prometheus_client import Counter, Histogram, make_asgi_app
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class MetricsError(Exception):
+    """Raised when metrics operations fail."""
+
+
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["app", "method", "path", "status_code"],
+)
+
+REQUEST_LATENCY = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency in seconds",
+    ["app", "method", "path"],
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Middleware collecting Prometheus metrics."""
+
+    def __init__(self, app: FastAPI, app_name: str) -> None:
+        super().__init__(app)
+        self.app_name = app_name
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+        try:
+            REQUEST_COUNT.labels(
+                self.app_name, request.method, request.url.path, str(response.status_code)
+            ).inc()
+            REQUEST_LATENCY.labels(
+                self.app_name, request.method, request.url.path
+            ).observe(duration)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise MetricsError("Failed to record metrics") from exc
+        return response
+
+
+def setup_metrics(app: FastAPI, app_name: str) -> None:
+    """Attach metrics middleware and expose /metrics endpoint."""
+    try:
+        app.add_middleware(MetricsMiddleware, app_name=app_name)
+        app.mount("/metrics", make_asgi_app())
+    except Exception as exc:  # pragma: no cover - defensive
+        raise MetricsError("Failed to set up metrics") from exc
+

--- a/python/src/common/service.py
+++ b/python/src/common/service.py
@@ -4,6 +4,11 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from src.utils import ExternalServiceError
+from .metrics import setup_metrics, MetricsError
+
+
+class ServiceCreationError(Exception):
+    """Raised when service creation fails."""
 
 
 async def _health() -> dict[str, str]:
@@ -11,17 +16,21 @@ async def _health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-def create_service() -> FastAPI:
-    """Create a FastAPI app with health and error handlers."""
-    app = FastAPI()
-    app.get("/health")(_health)
+def create_service(app_name: str = "service") -> FastAPI:
+    """Create a FastAPI app with health, metrics, and error handlers."""
+    try:
+        app = FastAPI()
+        app.get("/health")(_health)
+        setup_metrics(app, app_name)
 
-    @app.exception_handler(ExternalServiceError)
-    async def _handle_external(_: Request, exc: ExternalServiceError) -> JSONResponse:
-        return JSONResponse(status_code=502, content={"detail": str(exc)})
+        @app.exception_handler(ExternalServiceError)
+        async def _handle_external(_: Request, exc: ExternalServiceError) -> JSONResponse:
+            return JSONResponse(status_code=502, content={"detail": str(exc)})
 
-    @app.exception_handler(Exception)
-    async def _handle_general(_: Request, exc: Exception) -> JSONResponse:
-        return JSONResponse(status_code=500, content={"detail": str(exc)})
+        @app.exception_handler(Exception)
+        async def _handle_general(_: Request, exc: Exception) -> JSONResponse:
+            return JSONResponse(status_code=500, content={"detail": str(exc)})
 
-    return app
+        return app
+    except (MetricsError, Exception) as exc:  # pragma: no cover - defensive
+        raise ServiceCreationError("Failed to create service") from exc

--- a/python/src/mcp/mcp_server.py
+++ b/python/src/mcp/mcp_server.py
@@ -31,7 +31,7 @@ class RateLimitError(Exception):
     """Raised when rate limit is exceeded."""
 
 
-app = create_service()
+app = create_service("mcp")
 transport = SSETransport()
 
 

--- a/python/src/server/main.py
+++ b/python/src/server/main.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import socketio
 
 from src.common.logging import logger
+from src.common.metrics import setup_metrics, MetricsError
 
 from .config import settings
 from .auth.dependencies import require_role
@@ -27,6 +28,11 @@ class HealthCheckError(Exception):
 # FastAPI application
 api = FastAPI()
 logger.info("Server application created")
+
+try:
+    setup_metrics(api, "server")
+except MetricsError as exc:  # pragma: no cover - defensive
+    logger.error("Metrics setup failed", error=str(exc))
 
 api.add_middleware(
     CORSMiddleware,

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -1,0 +1,29 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.server import app as server_app
+from src.common.service import create_service
+
+mcp_app = create_service("mcp")
+agents_app = create_service("agents")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "app, app_name",
+    [
+        (server_app, "server"),
+        (mcp_app, "mcp"),
+        (agents_app, "agents"),
+    ],
+)
+async def test_metrics_endpoint(app, app_name) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/metrics/")
+        res = await client.get("/metrics/")
+    assert res.status_code == 200
+    body = res.text
+    assert "http_requests_total" in body
+    assert f'app="{app_name}"' in body
+    assert 'path="/metrics/"' in body


### PR DESCRIPTION
## Description
- add Prometheus metrics middleware for server, MCP, and agents services
- configure Prometheus to scrape each service and run via docker-compose
- add tests verifying /metrics returns request counters

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Performance impact assessed

## Security Checklist
- [x] Input validation implemented
- [x] No credentials in code
- [x] Error messages don't expose internals
- [ ] Authentication/authorization tested

## Checklist
- [x] Code follows project conventions
- [x] Type hints added for new code
- [x] Docstrings added for public functions
- [x] Logging implemented appropriately
- [x] Error handling implemented
- [x] Tests pass locally
- [x] No security vulnerabilities introduced

------
https://chatgpt.com/codex/tasks/task_e_68a3e13dcbe08322bc5fa633a8eff6f3