### PR TITLE
feat: provision grafana dashboards for microservices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,22 @@ services:
       - archon-mcp
       - archon-agents
 
+  grafana:
+    image: grafana/grafana:latest
+    container_name: Archon-Grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - PROMETHEUS_URL=${PROMETHEUS_URL:-http://prometheus:9090}
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - app-network
+    depends_on:
+      - prometheus
+
   jaeger:
     image: jaegertracing/all-in-one:1.57
     container_name: Archon-Jaeger

--- a/docs/docs/server-monitoring.mdx
+++ b/docs/docs/server-monitoring.mdx
@@ -1,6 +1,8 @@
----
+id: server-monitoring
 title: Server Monitoring
 sidebar_position: 6
+description: Import Grafana dashboards to observe Archon microservices.
+tags: [monitoring, grafana, observability]
 ---
 
 import Admonition from '@theme/Admonition';
@@ -92,6 +94,20 @@ docker-compose logs -f
 docker-compose logs -f archon-server
 docker-compose logs -f archon-mcp
 ```
+
+### Grafana Dashboards
+
+Import prebuilt Grafana dashboards to visualize latency, throughput, error rates, and CPU saturation for each microservice:
+
+1. Start the monitoring stack:
+
+   ```bash
+   docker-compose up -d grafana prometheus
+   ```
+
+2. Navigate to Grafana at `http://localhost:3000` and log in (default password `admin` unless overridden).
+3. The dashboards are provisioned from `monitoring/dashboards/` and appear under the "Archon" folder.
+4. Ensure the Prometheus data source URL is set via the `PROMETHEUS_URL` environment variable.
 
 ### Database Monitoring
 

--- a/monitoring/dashboards/archon-agents.json
+++ b/monitoring/dashboards/archon-agents.json
@@ -1,0 +1,97 @@
+{
+  "uid": "archon-agents",
+  "title": "Archon Agents Dashboard",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Latency p95",
+      "description": "95th percentile latency over 5m window",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service=\"archon-agents\"}[5m])) by (le))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Throughput",
+      "description": "Requests per second",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"archon-agents\"}[1m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Error Rate",
+      "description": "Percentage of 5xx responses",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"archon-agents\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=\"archon-agents\"}[5m])) * 100",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "CPU Saturation",
+      "description": "Average CPU usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "avg(rate(process_cpu_seconds_total{service=\"archon-agents\"}[1m])) * 100",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/dashboards/archon-mcp.json
+++ b/monitoring/dashboards/archon-mcp.json
@@ -1,0 +1,97 @@
+{
+  "uid": "archon-mcp",
+  "title": "Archon MCP Dashboard",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Latency p95",
+      "description": "95th percentile latency over 5m window",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service=\"archon-mcp\"}[5m])) by (le))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Throughput",
+      "description": "Requests per second",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"archon-mcp\"}[1m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Error Rate",
+      "description": "Percentage of 5xx responses",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"archon-mcp\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=\"archon-mcp\"}[5m])) * 100",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "CPU Saturation",
+      "description": "Average CPU usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "avg(rate(process_cpu_seconds_total{service=\"archon-mcp\"}[1m])) * 100",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/dashboards/archon-server.json
+++ b/monitoring/dashboards/archon-server.json
@@ -1,0 +1,97 @@
+{
+  "uid": "archon-server",
+  "title": "Archon Server Dashboard",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Latency p95",
+      "description": "95th percentile latency over 5m window",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service=\"archon-server\"}[5m])) by (le))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Throughput",
+      "description": "Requests per second",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"archon-server\"}[1m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Error Rate",
+      "description": "Percentage of 5xx responses",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"archon-server\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=\"archon-server\"}[5m])) * 100",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "CPU Saturation",
+      "description": "Average CPU usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "avg(rate(process_cpu_seconds_total{service=\"archon-server\"}[1m])) * 100",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: 'Archon'
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: ${PROMETHEUS_URL}
+    isDefault: true
+    jsonData:
+      timeInterval: 5s


### PR DESCRIPTION
## Summary
- add Grafana dashboards for server, MCP, and agents services
- provision Grafana and Prometheus via docker-compose with env-based datasource
- document importing dashboards in monitoring guide

## Testing
- `docker-compose -f docker-compose.yml config`
- `cd docs && npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3e9af352483228d1bd3654e9afaa7