### PR TITLE
feat: add prometheus alerting and runbook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       - "9090:9090"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/alerts.yml:/etc/prometheus/alerts.yml
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
     networks:
@@ -116,6 +117,7 @@ services:
       - archon-server
       - archon-mcp
       - archon-agents
+      - alertmanager
 
   grafana:
     image: grafana/grafana:latest
@@ -132,6 +134,26 @@ services:
       - app-network
     depends_on:
       - prometheus
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: Archon-Alertmanager
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    environment:
+      - ALERT_EMAIL_TO=${ALERT_EMAIL_TO:-}
+      - ALERT_EMAIL_FROM=${ALERT_EMAIL_FROM:-}
+      - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+    networks:
+      - app-network
 
   jaeger:
     image: jaegertracing/all-in-one:1.57

--- a/docs/docs/server-monitoring.mdx
+++ b/docs/docs/server-monitoring.mdx
@@ -183,6 +183,23 @@ Archon automatically manages resources:
 - **Connection Pooling**: Optimizes database performance
 - **Batch Processing**: Efficiently handles large document sets
 
+## 🚨 Alert Runbook
+
+### ErrorRateHigh
+1. Inspect service logs with `docker-compose logs -f <service>`.
+2. Verify recent deployments or configuration changes.
+3. If the error rate stays above threshold for 30 minutes, escalate to the backend on-call engineer.
+
+### LatencyHigh
+1. Check current load and upstream dependencies.
+2. Review Grafana dashboards for resource saturation.
+3. Escalate to the infrastructure team if latency persists beyond 30 minutes.
+
+### ServiceDown
+1. Attempt a restart: `docker-compose restart <service>`.
+2. If the service fails to start, gather logs and raise an incident in the ops channel.
+3. Escalate immediately to SRE if downtime exceeds 5 minutes.
+
 ---
 
 **Need Help?** Check the [Troubleshooting Guide](./troubleshooting) for detailed debugging steps.

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,13 @@
+route:
+  receiver: 'team-notifications'
+
+receivers:
+  - name: 'team-notifications'
+    email_configs:
+      - to: '${ALERT_EMAIL_TO}'
+        from: '${ALERT_EMAIL_FROM}'
+        smarthost: '${SMTP_HOST}:${SMTP_PORT}'
+        auth_username: '${SMTP_USERNAME}'
+        auth_password: '${SMTP_PASSWORD}'
+    webhook_configs:
+      - url: '${ALERT_WEBHOOK_URL}'

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -1,0 +1,34 @@
+groups:
+  - name: service-performance
+    rules:
+      - alert: ErrorRateHigh
+        expr: |
+          (sum(rate(http_requests_total{status=~"5.."}[5m])) by (job)) /
+          (sum(rate(http_requests_total[5m])) by (job)) > 0.005
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High error rate on {{ $labels.job }}
+          description: Error rate has exceeded 0.5% for the last 5 minutes.
+
+      - alert: LatencyHigh
+        expr: |
+          histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, job)) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High latency on {{ $labels.job }}
+          description: 95th percentile latency is above 200ms for the last 5 minutes.
+
+  - name: service-health
+    rules:
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: {{ $labels.job }} is down
+          description: Service {{ $labels.job }} has been unreachable for over 1 minute.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,6 +1,15 @@
 global:
   scrape_interval: ${PROMETHEUS_SCRAPE_INTERVAL:-15s}
 
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - 'alertmanager:9093'
+
 scrape_configs:
   - job_name: 'embedding-services'
     static_configs:

--- a/python/tests/test_prometheus_alerts.py
+++ b/python/tests/test_prometheus_alerts.py
@@ -1,0 +1,51 @@
+import asyncio
+import pathlib
+import shutil
+import pytest
+
+class PrometheusLintError(Exception):
+    """Raised when Prometheus configuration validation fails."""
+
+async def _run_promtool(args: list[str]) -> None:
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    except asyncio.TimeoutError as exc:
+        process.kill()
+        raise PrometheusLintError("promtool check timed out") from exc
+    if process.returncode != 0:
+        raise PrometheusLintError(stderr.decode())
+
+@pytest.mark.asyncio
+async def test_prometheus_config_syntax() -> None:
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is required for promtool validation")
+    root = pathlib.Path(__file__).resolve().parents[2] / "monitoring"
+    await _run_promtool([
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{root}:/etc/prometheus",
+        "prom/prometheus:latest",
+        "promtool",
+        "check",
+        "config",
+        "/etc/prometheus/prometheus.yml",
+    ])
+    await _run_promtool([
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{root}:/etc/prometheus",
+        "prom/prometheus:latest",
+        "promtool",
+        "check",
+        "rules",
+        "/etc/prometheus/alerts.yml",
+    ])


### PR DESCRIPTION
## Summary
- add Prometheus alert rules for error rate, latency, and service availability
- wire Alertmanager and rule files into compose stack
- document alert response runbook
- add promtool syntax test for alert rules

## Testing
- `npm --prefix docs install`
- `npm --prefix docs run build`
- `pytest python/tests/test_prometheus_alerts.py` *(fails: skipped - Docker is required for promtool validation)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ee2af2b88322b829de4dce0fd449