### PR TITLE
chore: add logfire dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,6 +5,7 @@
 fastapi>=0.116.1
 httpx>=0.28.1
 loguru>=0.7.3
+logfire>=4.3.3
 pydantic-settings>=2.10.1
 python-dotenv>=1.1.1
 python-multipart>=0.0.9


### PR DESCRIPTION
## Summary
- add logfire>=4.3.3 to Python production requirements

## Testing
- `uv sync --frozen --all-extras --dev` *(fails: Failed to parse `uv.lock`)*
- `uv run python -c "import logfire; print(logfire.__version__)"`
- `uv run pytest` *(fails: ImportError: cannot import name 'api' from 'src.server')*

------
https://chatgpt.com/codex/tasks/task_e_68a48b5bdb848322a8039ca3d090e3f1