### PR TITLE
[useSearchSocket] mock searchDocuments in test

### DIFF
--- a/archon-ui-main/tests/useSearchSocket.test.tsx
+++ b/archon-ui-main/tests/useSearchSocket.test.tsx
@@ -1,7 +1,8 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi, describe, it, expect } from 'vitest';
 import { useSearch } from '../src/hooks/useSearch';
+import * as api from '../src/services/api';
 import type { SearchCompleted } from '../src/hooks/useSocket';
 
 const handlers: Record<string, (data: SearchCompleted) => void> = {};
@@ -20,12 +21,14 @@ vi.mock('../src/hooks/useSocket', () => ({
 }));
 
 describe('useSearch socket integration', () => {
-  it('updates cache when search:completed fires', () => {
+  it('updates cache when search:completed fires', async () => {
     const client = new QueryClient();
+    vi.spyOn(api, 'searchDocuments').mockResolvedValue([]);
     const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       <QueryClientProvider client={client}>{children}</QueryClientProvider>
     );
     renderHook(() => useSearch('hello'), { wrapper });
+    await waitFor(() => expect(api.searchDocuments).toHaveBeenCalledWith('hello'));
     const results = [{ id: '1', title: 't', snippet: 's' }];
     handlers['search:completed']?.({ query: 'hello', results });
     expect(client.getQueryData(['search', 'hello'])).toEqual(results);


### PR DESCRIPTION
## Description
- mock `searchDocuments` in `useSearchSocket` test to prevent network calls
- assert the search API is invoked

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] `pnpm test tests/useSearchSocket.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4932b5c408322868733a5fef90fb7