### PR TITLE
[Logging] Integrate Logfire and enhance error logging

### DIFF
--- a/python/src/mcp/mcp_server.py
+++ b/python/src/mcp/mcp_server.py
@@ -10,12 +10,13 @@ from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from src.common.logging import logger, log_info
+from src.common.logging import logger, log_info, log_error
 from src.common.service import create_service
 
 from . import ToolExecutionError
 from .tools import TOOLS
 from .transport.sse import SSETransport
+
 
 class ConfigurationError(Exception):
     """Raised when required configuration is missing."""
@@ -99,7 +100,7 @@ async def rpc_endpoint(req: RPCRequest, request: Request) -> JSONResponse:
         try:
             result = await tool(req.params)
         except ToolExecutionError as exc:
-            logger.error("Tool execution failed", method=req.method, error=str(exc))
+            await log_error("Tool execution failed", method=req.method, error=str(exc))
             raise HTTPException(status_code=400, detail=str(exc)) from exc
     response = {"jsonrpc": "2.0", "id": req.id, "result": result}
     if req.client_id:

--- a/python/src/server/main.py
+++ b/python/src/server/main.py
@@ -12,14 +12,14 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import socketio
 
-from src.common.logging import logger
+from src.common.logging import logger, log_info
 from src.common.metrics import MetricsError, setup_metrics
 from src.common.tracing import TracingSetupError, setup_tracing
 
 from .config import settings
 from .auth.dependencies import require_role
 from .routes import auth, documents, health, projects, sources, search
-from .socket import connect, disconnect, sio
+from .socket import sio
 
 
 class HealthCheckError(Exception):
@@ -28,7 +28,13 @@ class HealthCheckError(Exception):
 
 # FastAPI application
 api = FastAPI()
-logger.info("Server application created")
+
+
+@api.on_event("startup")
+async def _log_startup() -> None:
+    """Log server startup."""
+    await log_info("Server application started")
+
 
 try:
     setup_tracing("server", api)

--- a/python/tests/test_agents.py
+++ b/python/tests/test_agents.py
@@ -2,7 +2,6 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.agents.main import app
-from src.common import logging as log_module
 
 
 @pytest.mark.asyncio
@@ -24,19 +23,17 @@ async def test_run_compute() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_invalid() -> None:
+async def test_run_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     transport = ASGITransport(app=app)
-    called: dict[str, str] = {}
+    called: list[str] = []
 
     async def fake_log_error(message: str, **data):
-        called["message"] = message
+        called.append(message)
 
     # Patch logging to capture error log
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(log_module, "log_error", fake_log_error)
+    monkeypatch.setattr("src.agents.main.log_error", fake_log_error)
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         res = await client.post("/run", json={"task": "bad"})
     assert res.status_code == 400
-    assert called["message"] == "Unsupported task"
-    monkeypatch.undo()
+    assert called[0] == "Unsupported task"


### PR DESCRIPTION
## Summary
- log Logfire on server startup and leverage async error logging in MCP server
- test error logging for failing MCP tools
- adjust agent logging tests for structured logger

## Testing
- `uv run --no-sync ruff format src/server/main.py src/mcp/mcp_server.py tests/test_mcp_server.py`
- `uv run --no-sync ruff check src/server/main.py src/mcp/mcp_server.py tests/test_mcp_server.py`
- `uv run --no-sync ruff format tests/test_agents.py`
- `uv run --no-sync ruff check tests/test_agents.py`
- `uv run --no-sync pytest tests/test_logging.py tests/test_agents.py tests/test_mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68a49b25e2dc83229a06b779f7b40848