### PR TITLE
[Docs] Add Grafana dashboards for microservices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,8 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - PROMETHEUS_URL=${PROMETHEUS_URL:-http://prometheus:9090}
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/archon-server.json
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
       - ./monitoring/dashboards:/var/lib/grafana/dashboards

--- a/docs/docs/server-monitoring.mdx
+++ b/docs/docs/server-monitoring.mdx
@@ -99,15 +99,25 @@ docker-compose logs -f archon-mcp
 
 Import prebuilt Grafana dashboards to visualize latency, throughput, error rates, and CPU saturation for each microservice:
 
-1. Start the monitoring stack:
+1. Set the Prometheus data source URL:
+
+   ```bash
+   export PROMETHEUS_URL=http://prometheus:9090
+   ```
+
+2. Start the monitoring stack:
 
    ```bash
    docker-compose up -d grafana prometheus
    ```
 
-2. Navigate to Grafana at `http://localhost:3000` and log in (default password `admin` unless overridden).
-3. The dashboards are provisioned from `monitoring/dashboards/` and appear under the "Archon" folder.
-4. Ensure the Prometheus data source URL is set via the `PROMETHEUS_URL` environment variable.
+3. Open Grafana at `http://localhost:3000` and log in (default password `admin` unless overridden).
+4. Dashboards for each service appear under the **Archon** folder:
+   - **Archon Server** – API layer metrics
+   - **Archon MCP** – model control plane metrics
+   - **Archon Agents** – agent service metrics
+   - **Archon Frontend** – web UI metrics
+5. To import a dashboard manually, go to **Dashboards → Import → Upload JSON** and select a file from `monitoring/dashboards/`.
 
 ### Database Monitoring
 

--- a/monitoring/dashboards/archon-frontend.json
+++ b/monitoring/dashboards/archon-frontend.json
@@ -1,0 +1,97 @@
+{
+  "uid": "archon-frontend",
+  "title": "Archon Frontend Dashboard",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Latency p95",
+      "description": "95th percentile latency over 5m window",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service=\"frontend\"}[5m])) by (le))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Throughput",
+      "description": "Requests per second",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"frontend\"}[1m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Error Rate",
+      "description": "Percentage of 5xx responses",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"frontend\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=\"frontend\"}[5m])) * 100",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "CPU Saturation",
+      "description": "Average CPU usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "avg(rate(process_cpu_seconds_total{service=\"frontend\"}[1m])) * 100",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- monitor frontend service with new Grafana dashboard covering latency, throughput, error rate and saturation
- provision Grafana via docker-compose for auto-loaded dashboards
- document dashboard import steps for all microservices

## Testing
- `npm --prefix docs install`
- `npm --prefix docs run build`
- `docker compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4ae9211208322af978445310d04c1