### PR TITLE
feat: add repository abstraction

### DIFF
--- a/python/src/server/repositories/__init__.py
+++ b/python/src/server/repositories/__init__.py
@@ -1,0 +1,9 @@
+from .base_repository import BaseRepository, RepositoryError
+from .supabase_repository import SupabaseRepository, SupabaseRepositoryError
+
+__all__ = [
+    "BaseRepository",
+    "RepositoryError",
+    "SupabaseRepository",
+    "SupabaseRepositoryError",
+]

--- a/python/src/server/repositories/base_repository.py
+++ b/python/src/server/repositories/base_repository.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generic, Tuple, TypeVar
+
+T = TypeVar("T", bound=Dict[str, Any])
+
+
+class RepositoryError(Exception):
+    """Base exception for repository errors."""
+
+
+class BaseRepository(ABC, Generic[T]):
+    """Abstract base class defining async CRUD operations."""
+
+    @abstractmethod
+    async def create(self, data: T) -> Tuple[bool, Dict[str, Any]]:
+        """Insert a new record."""
+
+    @abstractmethod
+    async def read(self, item_id: Any) -> Tuple[bool, Dict[str, Any]]:
+        """Fetch a record by its identifier."""
+
+    @abstractmethod
+    async def update(self, item_id: Any, data: T) -> Tuple[bool, Dict[str, Any]]:
+        """Update an existing record."""
+
+    @abstractmethod
+    async def delete(self, item_id: Any) -> Tuple[bool, Dict[str, Any]]:
+        """Delete a record by its identifier."""

--- a/python/src/server/repositories/supabase_repository.py
+++ b/python/src/server/repositories/supabase_repository.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Generic, Tuple, TypeVar
+
+import httpx
+from supabase import AsyncClient
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from .base_repository import BaseRepository, RepositoryError
+
+T = TypeVar("T", bound=Dict[str, Any])
+
+
+class SupabaseRepositoryError(RepositoryError):
+    """Raised when Supabase operations fail."""
+
+
+class SupabaseRepository(BaseRepository[T], Generic[T]):
+    """Supabase implementation of the repository pattern."""
+
+    def __init__(self, client: AsyncClient, table: str) -> None:
+        if not table:
+            raise SupabaseRepositoryError("table name required")
+        self._client = client
+        self._table = table
+
+    async def _execute(self, builder: Any) -> Tuple[bool, Dict[str, Any]]:
+        try:
+            async for attempt in AsyncRetrying(
+                retry=retry_if_exception_type(httpx.HTTPError),
+                stop=stop_after_attempt(3),
+                wait=wait_exponential(min=1, max=4),
+            ):
+                with attempt:
+                    response = await builder.execute()
+                    return True, response.data
+        except Exception as exc:
+            return False, {"error": str(exc)}
+
+    async def create(self, data: T) -> Tuple[bool, Dict[str, Any]]:
+        if not isinstance(data, dict) or not data:
+            raise SupabaseRepositoryError("invalid data")
+        builder = self._client.table(self._table).insert(data)
+        return await self._execute(builder)
+
+    async def read(self, item_id: Any) -> Tuple[bool, Dict[str, Any]]:
+        if not item_id:
+            raise SupabaseRepositoryError("invalid id")
+        builder = self._client.table(self._table).select("*").eq("id", item_id).single()
+        return await self._execute(builder)
+
+    async def update(self, item_id: Any, data: T) -> Tuple[bool, Dict[str, Any]]:
+        if not item_id:
+            raise SupabaseRepositoryError("invalid id")
+        if not isinstance(data, dict) or not data:
+            raise SupabaseRepositoryError("invalid data")
+        builder = (
+            self._client.table(self._table).update(data).eq("id", item_id).single()
+        )
+        return await self._execute(builder)
+
+    async def delete(self, item_id: Any) -> Tuple[bool, Dict[str, Any]]:
+        if not item_id:
+            raise SupabaseRepositoryError("invalid id")
+        builder = self._client.table(self._table).delete().eq("id", item_id).single()
+        return await self._execute(builder)

--- a/python/tests/test_repositories.py
+++ b/python/tests/test_repositories.py
@@ -1,0 +1,94 @@
+import pytest
+import httpx
+
+from src.server.repositories import (
+    BaseRepository,
+    SupabaseRepository,
+    SupabaseRepositoryError,
+)
+
+
+class FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeBuilder:
+    def __init__(self, data, raise_error=False):
+        self.data = data
+        self.raise_error = raise_error
+
+    async def execute(self):
+        if self.raise_error:
+            raise httpx.HTTPError("boom")
+        return FakeResponse(self.data)
+
+
+class FakeTable:
+    def __init__(self, response=None, raise_error=False):
+        self.response = response or {}
+        self.raise_error = raise_error
+
+    def insert(self, data):
+        return FakeBuilder(data, self.raise_error)
+
+    def select(self, *_):
+        return self
+
+    def eq(self, *_):
+        return self
+
+    def single(self):
+        return FakeBuilder(self.response, self.raise_error)
+
+    def update(self, data):
+        return FakeBuilder(data, self.raise_error)
+
+    def delete(self):
+        return FakeBuilder(self.response, self.raise_error)
+
+
+class FakeClient:
+    def __init__(self, response=None, raise_error=False):
+        self.response = response or {}
+        self.raise_error = raise_error
+
+    def table(self, _name):
+        return FakeTable(self.response, self.raise_error)
+
+
+def test_base_repository_abstract():
+    with pytest.raises(TypeError):
+        BaseRepository()
+
+
+@pytest.mark.asyncio
+async def test_supabase_repository_crud_success():
+    client = FakeClient({"id": 1, "name": "x"})
+    repo: SupabaseRepository[dict[str, str]] = SupabaseRepository(client, "items")
+    ok, created = await repo.create({"name": "x"})
+    assert ok and created["name"] == "x"
+    ok, fetched = await repo.read(1)
+    assert ok and fetched["id"] == 1
+    ok, updated = await repo.update(1, {"name": "y"})
+    assert ok and updated["name"] == "y"
+    ok, deleted = await repo.delete(1)
+    assert ok and "id" in deleted
+
+
+@pytest.mark.asyncio
+async def test_supabase_repository_invalid_input():
+    client = FakeClient()
+    repo: SupabaseRepository[dict[str, str]] = SupabaseRepository(client, "items")
+    with pytest.raises(SupabaseRepositoryError):
+        await repo.create({})
+    with pytest.raises(SupabaseRepositoryError):
+        await repo.read("")
+
+
+@pytest.mark.asyncio
+async def test_supabase_repository_failure():
+    client = FakeClient(raise_error=True)
+    repo: SupabaseRepository[dict[str, str]] = SupabaseRepository(client, "items")
+    ok, result = await repo.read(1)
+    assert not ok and "error" in result


### PR DESCRIPTION
## Summary
- add generic repository interface and Supabase implementation
- expose repositories package and add tests

## Testing
- `ruff format python/src/server/repositories python/tests/test_repositories.py`
- `ruff check python/src/server/repositories python/tests/test_repositories.py`
- `pyright python/src/server/repositories python/tests/test_repositories.py` *(fails: Import "httpx" could not be resolved; Import "supabase" could not be resolved; Import "tenacity" could not be resolved; Function with declared return type "Tuple[bool, Dict[str, Any]]" must return value on all code paths; Import "httpx" could not be resolved; Cannot instantiate abstract class "BaseRepository")*
- `pytest python/tests/test_repositories.py -v` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1e6fc4c8322894363b343a96499