### PR TITLE
chore: add httpx supabase and tenacity to dev requirements

### DIFF
--- a/python/requirements.dev.txt
+++ b/python/requirements.dev.txt
@@ -7,9 +7,12 @@
 
 # Development-only dependencies
 black>=25.1.0
+httpx>=0.28.1
 pytest>=8.4.1
 pytest-asyncio>=1.1.0
 pytest-cov>=6.2.1
+supabase>=2.18.1
+tenacity>=9.1.2
 
 # Additional recommended development tools (not in pyproject.toml but commonly used)
 # Uncomment if needed:


### PR DESCRIPTION
## Summary
- include httpx, supabase, and tenacity in python development requirements

## Testing
- `uv run pytest` *(fails: Failed to parse `uv.lock` at line 3)*

------
https://chatgpt.com/codex/tasks/task_e_68a4df08ba9c8322a9b3ae97d2c0af09