### PR TITLE
refactor: add source management service with repository pattern

### DIFF
--- a/python/src/server/services/__init__.py
+++ b/python/src/server/services/__init__.py
@@ -1,11 +1,17 @@
 """Service layer exports."""
 
-from .database import DatabaseService, DatabaseError
+from .database import DatabaseError, DatabaseService
 from .supabase_client import SupabaseClient, SupabaseClientError
+from .source_management_service import (
+    SourceManagementError,
+    SourceManagementService,
+)
 
 __all__ = [
     "DatabaseService",
     "DatabaseError",
     "SupabaseClient",
     "SupabaseClientError",
+    "SourceManagementService",
+    "SourceManagementError",
 ]

--- a/python/src/server/services/source_management_service.py
+++ b/python/src/server/services/source_management_service.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Any, Dict, Protocol, Tuple
+
+
+class SourceRepository(Protocol):
+    """Protocol for source data access."""
+
+    async def list_sources(self) -> Tuple[bool, Dict[str, Any]]: ...
+
+    async def delete(self, source_id: str) -> Tuple[bool, Dict[str, Any]]: ...
+
+    async def update(
+        self, source_id: str, metadata: Dict[str, Any]
+    ) -> Tuple[bool, Dict[str, Any]]: ...
+
+
+class SourceManagementError(Exception):
+    """Custom exception for source management failures."""
+
+
+class SourceManagementService:
+    """Service for managing knowledge sources."""
+
+    def __init__(self, repository: SourceRepository) -> None:
+        self._repo = repository
+        self._logger = logging.getLogger(__name__)
+
+    async def get_available_sources(self) -> Tuple[bool, Dict[str, Any]]:
+        """Return all available sources."""
+        try:
+            ok, data = await self._repo.list_sources()
+            if not ok:
+                return False, data
+            sources = data.get("sources", [])
+            return True, {"sources": sources, "total_count": len(sources)}
+        except Exception as exc:
+            self._logger.error("get_available_sources failed: %s", exc)
+            raise SourceManagementError("failed to fetch sources") from exc
+
+    async def delete_source(self, source_id: str) -> Tuple[bool, Dict[str, Any]]:
+        """Delete a source by its identifier."""
+        if not source_id:
+            return False, {"error": "invalid source id"}
+        try:
+            ok, data = await self._repo.delete(source_id)
+            if ok:
+                self._logger.info("Deleted source %s", source_id)
+            else:
+                self._logger.error(
+                    "Failed to delete source %s: %s", source_id, data.get("error")
+                )
+            return ok, data
+        except Exception as exc:
+            self._logger.error("delete_source failed: %s", exc)
+            raise SourceManagementError("failed to delete source") from exc
+
+    async def update_source_metadata(
+        self, source_id: str, metadata: Dict[str, Any]
+    ) -> Tuple[bool, Dict[str, Any]]:
+        """Update metadata for a given source."""
+        if not source_id or not isinstance(metadata, dict) or not metadata:
+            return False, {"error": "invalid input"}
+        try:
+            ok, data = await self._repo.update(source_id, metadata)
+            if ok:
+                self._logger.info("Updated source %s", source_id)
+            else:
+                self._logger.error(
+                    "Failed to update source %s: %s", source_id, data.get("error")
+                )
+            return ok, data
+        except Exception as exc:
+            self._logger.error("update_source_metadata failed: %s", exc)
+            raise SourceManagementError("failed to update source") from exc

--- a/python/tests/test_source_management_service.py
+++ b/python/tests/test_source_management_service.py
@@ -1,0 +1,92 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "source_management_service",
+    Path(__file__).parents[1] / "src/server/services/source_management_service.py",
+)
+if spec is None or spec.loader is None:
+    raise ImportError("module spec not found")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+SourceManagementService = module.SourceManagementService
+SourceManagementError = module.SourceManagementError
+
+
+class GoodRepo:
+    async def list_sources(self):
+        return True, {"sources": [{"id": "1"}]}
+
+    async def delete(self, source_id: str):
+        return True, {"source": source_id}
+
+    async def update(self, source_id: str, metadata: dict):
+        return True, {"source": source_id, "metadata": metadata}
+
+
+class FailingRepo:
+    async def list_sources(self):
+        return False, {"error": "db"}
+
+    async def delete(self, source_id: str):
+        return False, {"error": "missing"}
+
+    async def update(self, source_id: str, metadata: dict):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_get_available_sources_success():
+    service = SourceManagementService(GoodRepo())
+    ok, data = await service.get_available_sources()
+    assert ok is True
+    assert data["total_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_available_sources_failure():
+    service = SourceManagementService(FailingRepo())
+    ok, data = await service.get_available_sources()
+    assert ok is False
+    assert data["error"] == "db"
+
+
+@pytest.mark.asyncio
+async def test_delete_source_validation():
+    service = SourceManagementService(GoodRepo())
+    ok, data = await service.delete_source("")
+    assert ok is False
+    assert "error" in data
+
+
+@pytest.mark.asyncio
+async def test_delete_source_failure():
+    service = SourceManagementService(FailingRepo())
+    ok, data = await service.delete_source("abc")
+    assert ok is False
+    assert data["error"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_update_source_metadata_success():
+    service = SourceManagementService(GoodRepo())
+    ok, data = await service.update_source_metadata("1", {"a": 1})
+    assert ok is True
+    assert data["metadata"]["a"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_source_metadata_invalid_input():
+    service = SourceManagementService(GoodRepo())
+    ok, data = await service.update_source_metadata("", {})
+    assert ok is False
+    assert "error" in data
+
+
+@pytest.mark.asyncio
+async def test_update_source_metadata_exception():
+    service = SourceManagementService(FailingRepo())
+    with pytest.raises(SourceManagementError):
+        await service.update_source_metadata("1", {"a": 1})


### PR DESCRIPTION
## Summary
- add SourceManagementService using repository abstraction
- expose new service in service package
- test SourceManagementService behaviors

## Testing
- `ruff format src/server/services/source_management_service.py src/server/services/__init__.py tests/test_source_management_service.py`
- `ruff check src/server/services/source_management_service.py src/server/services/__init__.py tests/test_source_management_service.py --fix`
- `pyright src/server/services/source_management_service.py tests/test_source_management_service.py`
- `pytest tests/test_source_management_service.py -v`
- `pytest tests/ -v --cov=src` *(fails: no module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68a4edb92760832287f88f04fffe1408