### PR TITLE
[Server] Add MCP middleware

### DIFF
--- a/python/src/server/middleware/__init__.py
+++ b/python/src/server/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""Server middleware package."""
+
+from .mcp_middleware import MCPMiddleware
+
+__all__ = ["MCPMiddleware"]

--- a/python/src/server/middleware/mcp_middleware.py
+++ b/python/src/server/middleware/mcp_middleware.py
@@ -1,0 +1,86 @@
+"""Middleware for handling MCP requests directly."""
+
+from __future__ import annotations
+
+import asyncio
+from json import JSONDecodeError
+from typing import Any, Awaitable, Callable, Dict
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp
+
+
+class InvalidMCPPayloadError(Exception):
+    """Raised when MCP payload validation fails."""
+
+
+class MCPServiceError(Exception):
+    """Raised when the MCP service call fails."""
+
+
+Handler = Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]]
+
+
+class MCPMiddleware(BaseHTTPMiddleware):
+    """Intercepts MCP requests and routes them to handlers."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        handlers: Dict[str, Handler],
+        *,
+        retries: int = 3,
+        timeout: float = 5.0,
+    ) -> None:
+        super().__init__(app)
+        self.handlers = handlers
+        self.retries = retries
+        self.timeout = timeout
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        if not self._is_mcp_request(request):
+            return await call_next(request)
+        handler = self.handlers.get(request.url.path)
+        if handler is None:
+            return await call_next(request)
+        try:
+            payload = await request.json()
+        except JSONDecodeError as exc:
+            raise InvalidMCPPayloadError("invalid_json") from exc
+        try:
+            self._validate_payload(payload)
+            result = await self._call_handler_with_retry(handler, payload)
+            return JSONResponse(result)
+        except InvalidMCPPayloadError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except MCPServiceError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=504)
+
+    @staticmethod
+    def _is_mcp_request(request: Request) -> bool:
+        header = request.headers.get("X-MCP-Request") == "true"
+        ctype = request.headers.get("content-type") == "application/mcp+json"
+        return header or ctype
+
+    @staticmethod
+    def _validate_payload(payload: Any) -> None:
+        if not isinstance(payload, dict) or "action" not in payload:
+            raise InvalidMCPPayloadError("missing_action")
+
+    async def _call_handler_with_retry(
+        self, handler: Handler, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        for attempt in range(self.retries):
+            try:
+                return await asyncio.wait_for(handler(payload), timeout=self.timeout)
+            except asyncio.TimeoutError as exc:
+                if attempt == self.retries - 1:
+                    raise MCPServiceError("timeout") from exc
+                await asyncio.sleep(2 ** attempt)
+            except Exception as exc:
+                raise MCPServiceError("handler_error") from exc
+        raise MCPServiceError("unreachable")

--- a/python/tests/test_mcp_middleware.py
+++ b/python/tests/test_mcp_middleware.py
@@ -1,0 +1,48 @@
+import asyncio
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.server.middleware import MCPMiddleware
+
+
+@pytest.mark.asyncio
+async def test_mcp_request_routed() -> None:
+    app = FastAPI()
+    async def handler(payload):
+        return {"content": "ok"}
+    app.add_middleware(MCPMiddleware, handlers={"/mcp": handler}, retries=1)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post("/mcp", headers={"X-MCP-Request": "true"}, json={"action": "ping"})
+    assert res.status_code == 200
+    assert res.json() == {"content": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_invalid_payload_returns_400() -> None:
+    app = FastAPI()
+    async def handler(payload):
+        return {"content": "ok"}
+    app.add_middleware(MCPMiddleware, handlers={"/mcp": handler})
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post("/mcp", headers={"X-MCP-Request": "true"}, json={"bad": "data"})
+    assert res.status_code == 400
+    assert res.json()["error"] == "missing_action"
+
+
+@pytest.mark.asyncio
+async def test_handler_timeout_retries() -> None:
+    app = FastAPI()
+    calls = {"count": 0}
+    async def handler(payload):
+        calls["count"] += 1
+        await asyncio.sleep(0.2)
+        return {"content": "late"}
+    app.add_middleware(MCPMiddleware, handlers={"/mcp": handler}, timeout=0.05, retries=2)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post("/mcp", headers={"X-MCP-Request": "true"}, json={"action": "ping"})
+    assert res.status_code == 504
+    assert calls["count"] == 2


### PR DESCRIPTION
## Description
- add async MCPMiddleware to route MCP requests directly to service handlers
- test MCP middleware for routing, validation, and timeout logic

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Performance impact assessed

## Security Checklist
- [x] Input validation implemented
- [x] No credentials in code
- [x] Error messages don't expose internals
- [ ] Authentication/authorization tested

## Checklist
- [x] Code follows project conventions
- [x] Type hints added for new code
- [x] Docstrings added for public functions
- [ ] Logging implemented appropriately
- [x] Error handling implemented
- [x] Tests pass locally
- [x] No security vulnerabilities introduced

------
https://chatgpt.com/codex/tasks/task_e_68a4f2131b308322aa856a972362725b